### PR TITLE
fix: path-to-regexp deps for tegg-controller-plugin

### DIFF
--- a/plugin/controller/package.json
+++ b/plugin/controller/package.json
@@ -52,7 +52,8 @@
     "@eggjs/tegg-metadata": "^0.1.13",
     "@eggjs/tegg-runtime": "^0.1.13",
     "@types/koa-router": "^7.0.40",
-    "koa-compose": "^3.2.1"
+    "koa-compose": "^3.2.1",
+    "path-to-regexp": "^1.8.0"
   },
   "devDependencies": {
     "@eggjs/module-test-util": "^0.1.13",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->
Related ISSUE:
https://github.com/eggjs/tegg/issues/15
Related PR:
https://github.com/eggjs/tegg/pull/17

I think `path-to-regexp@1.8.0` should be added in dependencies to avoid MISSING ERROR when add `@eggjs/tegg-controller-plugin` additionally

`path-to-regexp@2.x` no longer has default export.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->