### PR TITLE
fix: should throw when inject context proto in singleton

### DIFF
--- a/core/metadata/src/errors.ts
+++ b/core/metadata/src/errors.ts
@@ -4,6 +4,7 @@ import { EggPrototypeName, QualifierInfo } from '@eggjs/core-decorator';
 export enum ErrorCodes {
   EGG_PROTO_NOT_FOUND = 'EGG_PROTO_NOT_FOUND',
   MULTI_PROTO_FOUND = 'MULTI_PROTO_FOUND',
+  INCOMPATIBLE_PROTO_INJECT = 'INCOMPATIBLE_PROTO_INJECT',
 }
 
 export class TeggError extends FrameworkBaseError {
@@ -25,5 +26,11 @@ export class MultiPrototypeFound extends TeggError {
   constructor(name: EggPrototypeName, qualifier: QualifierInfo[], result?: string) {
     const msg = `multi proto found for name:${String(name)} and qualifiers ${JSON.stringify(qualifier)}${result ? `, result is ${result}` : ''}`;
     super(msg, ErrorCodes.MULTI_PROTO_FOUND);
+  }
+}
+
+export class IncompatibleProtoInject extends TeggError {
+  constructor(msg: string) {
+    super(msg, ErrorCodes.INCOMPATIBLE_PROTO_INJECT);
   }
 }

--- a/core/metadata/src/impl/EggPrototypeBuilder.ts
+++ b/core/metadata/src/impl/EggPrototypeBuilder.ts
@@ -4,15 +4,16 @@ import {
   EggProtoImplClass,
   EggPrototypeName, InitTypeQualifierAttribute,
   ObjectInitTypeLike, PrototypeUtil,
-  QualifierInfo, QualifierUtil,
+  QualifierInfo, QualifierUtil, ObjectInitType,
   DEFAULT_PROTO_IMPL_TYPE } from '@eggjs/core-decorator';
 import { LoadUnit } from '../model/LoadUnit';
 import { EggPrototype, EggPrototypeLifecycleContext, InjectObjectProto } from '../model/EggPrototype';
 import { EggPrototypeFactory } from '../factory/EggPrototypeFactory';
 import { IdenticalUtil } from '@eggjs/tegg-lifecycle';
+import { FrameworkErrorFormater } from 'egg-errors';
 import { EggPrototypeImpl } from '../impl/EggPrototypeImpl';
 import { EggPrototypeCreatorFactory } from '../factory/EggPrototypeCreatorFactory';
-import { MultiPrototypeFound } from '../errors';
+import { MultiPrototypeFound, IncompatibleProtoInject } from '../errors';
 
 export interface InjectObject {
   /**
@@ -82,6 +83,13 @@ export class EggPrototypeBuilder {
           throw e;
         }
       }
+
+      // throw when try to inject ContextProto into singleton
+      if (this.initType === ObjectInitType.SINGLETON && proto.initType === ObjectInitType.CONTEXT) {
+        const err = new IncompatibleProtoInject(`can not inject ContextProto(${String(proto.name)}) in SingletonProto(${String(this.name)})`);
+        throw FrameworkErrorFormater.formatError(err);
+      }
+
       injectObjectProtos.push({
         refName: injectObject.refName,
         objName: injectObject.objName,

--- a/core/metadata/test/LoadUnit.test.ts
+++ b/core/metadata/test/LoadUnit.test.ts
@@ -57,6 +57,18 @@ describe('test/LoadUnit/LoadUnit.test.ts', () => {
         assert(e.message.includes('faq/TEGG_MULTI_PROTO_FOUND'));
       }
     });
+
+    it('should init failed with incompatilble proto injection', async () => {
+      const invalidateModulePath = path.join(__dirname, './fixtures/modules/incompatible-proto-inject');
+      const loader = new TestLoader(invalidateModulePath);
+      try {
+        await LoadUnitFactory.createLoadUnit(invalidateModulePath, EggLoadUnitType.MODULE, loader);
+        throw new Error('should throw error');
+      } catch (e) {
+        assert(e.message.includes('can not inject ContextProto(logger) in SingletonProto(base)'));
+        assert(e.message.includes('faq/TEGG_INCOMPATIBLE_PROTO_INJECT'));
+      }
+    });
   });
 
   describe('try use obj init type as property init type qualifier', () => {

--- a/core/metadata/test/fixtures/modules/incompatible-proto-inject/package.json
+++ b/core/metadata/test/fixtures/modules/incompatible-proto-inject/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "incompatible-proto-inject",
+  "eggModule": {
+    "name": "extendsModule"
+  }
+}

--- a/core/metadata/test/fixtures/modules/incompatible-proto-inject/test.ts
+++ b/core/metadata/test/fixtures/modules/incompatible-proto-inject/test.ts
@@ -1,0 +1,11 @@
+import { ContextProto, Inject, SingletonProto } from '@eggjs/core-decorator';
+
+@ContextProto()
+export class Logger {
+}
+
+@SingletonProto()
+export class Base {
+  @Inject()
+  logger: Logger;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

如果发现在 SingletonProto 中 inject ContextProto 报通用错误码错误，不然执行到后面都是 `ctx is required` 的错误，让人比较困惑。
