### PR TITLE
feat: optimize globby filepattern

### DIFF
--- a/core/common-util/src/ModuleConfig.ts
+++ b/core/common-util/src/ModuleConfig.ts
@@ -59,7 +59,7 @@ export class ModuleConfigUtil {
       // not load node_modules
       '!**/node_modules',
       // not load files in .xxx/
-      '!+(.*)/**',
+      '!**/+(.*)/**',
       // not load test/coverage
       '!**/test',
       '!**/coverage',

--- a/core/common-util/src/ModuleConfig.ts
+++ b/core/common-util/src/ModuleConfig.ts
@@ -56,8 +56,13 @@ export class ModuleConfigUtil {
     const realOptions: ReadModuleReferenceOptions = Object.assign({}, DEFAULT_READ_MODULE_REF_OPTS, options);
     const packagePaths = globby.sync([
       '**/package.json',
+      // not load node_modules
       '!**/node_modules',
-      '!.*/**',
+      // not load files in .xxx/
+      '!+(.*)/**',
+      // not load test/coverage
+      '!**/test',
+      '!**/coverage',
     ], {
       cwd: baseDir,
       deep: realOptions.deep,

--- a/core/common-util/test/fixtures/apps/app-with-no-module-json/.sff/.other/module-d/package.json
+++ b/core/common-util/test/fixtures/apps/app-with-no-module-json/.sff/.other/module-d/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "module-d",
+  "eggModule": {
+    "name": "moduleD"
+  }
+}

--- a/core/common-util/test/fixtures/apps/app-with-no-module-json/app/module-b/test/fixtures/module-e/package.json
+++ b/core/common-util/test/fixtures/apps/app-with-no-module-json/app/module-b/test/fixtures/module-e/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "module-e",
+  "eggModule": {
+    "name": "moduleE"
+  }
+}

--- a/core/loader/src/LoaderUtil.ts
+++ b/core/loader/src/LoaderUtil.ts
@@ -28,12 +28,15 @@ export class LoaderUtil {
     const filePattern = [
       // load file end with node module allow extensions
       `**/*.(${extensionPattern})`,
+      // not load files in .xxx/
+      '!+(.*)/**',
       // not load node module
       '!**/node_modules',
       // node load type defintions
       '!**/*.d.ts',
-      // not load test files
+      // not load test/coverage files
       '!**/test',
+      '!**/coverage',
       // extra file pattern
       ...(this.config.extraFilePattern || []),
     ];

--- a/core/loader/src/LoaderUtil.ts
+++ b/core/loader/src/LoaderUtil.ts
@@ -29,7 +29,7 @@ export class LoaderUtil {
       // load file end with node module allow extensions
       `**/*.(${extensionPattern})`,
       // not load files in .xxx/
-      '!+(.*)/**',
+      '!**/+(.*)/**',
       // not load node module
       '!**/node_modules',
       // node load type defintions

--- a/core/loader/test/Loader.test.ts
+++ b/core/loader/test/Loader.test.ts
@@ -20,7 +20,7 @@ describe('test/loader/Loader.test.ts', () => {
       assert(userRepoProto);
     });
 
-    it('should not load test files', () => {
+    it('should not load test/coverage files', () => {
       const repoModulePath = path.join(__dirname, './fixtures/modules/module-with-test');
       const loader = LoaderFactory.createLoader(repoModulePath, EggLoadUnitType.MODULE);
       const prototypes = loader.load();

--- a/core/loader/test/fixtures/modules/module-with-extra/.dist/ThrowError.ts
+++ b/core/loader/test/fixtures/modules/module-with-extra/.dist/ThrowError.ts
@@ -1,0 +1,1 @@
+throw new Error('should not load me');

--- a/core/loader/test/fixtures/modules/module-with-test/.gitignore
+++ b/core/loader/test/fixtures/modules/module-with-test/.gitignore
@@ -1,0 +1,1 @@
+!coverage

--- a/core/loader/test/fixtures/modules/module-with-test/coverage/fixtures/UserRepo.ts
+++ b/core/loader/test/fixtures/modules/module-with-test/coverage/fixtures/UserRepo.ts
@@ -1,0 +1,5 @@
+import { Prototype } from '@eggjs/core-decorator';
+
+@Prototype()
+export default class UserRepo {
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

优化扫文件的逻辑。

1. 把 coverage 目录也加上忽略的目录
2. 将 `!.*/**` 改成 `!+(.*)/**` 以匹配 .xx/.xx/ 这种目录结构


第二点再详细描述一下，因为 dot 没开，所以后面的 `**` 不会匹配 .xxx 这种路径，所以 `.*/**` 只能匹配 `.xxx/xxx/xx` 这种目录，而不能匹配 `.xxx/.xxx/xxxx` 这种。从而导致 globby 在进行是否要进行深度遍历的时候没法 match 到，从而一直遍历进去。

这个带来的问题就是，当一旦存在 `.xxx/.xxx/node_modules` 之后，globby.sync 就能扫到 oom 。

而配成 `!+(.*)/**` 就能解决这个问题，因为生成的正则不太一样，能匹配 `.xxx` 直接在第一层级就停止进一步的深度遍历，估计跟 micromatch 的实现有关

复现 case：https://github.com/whxaxes/test-globby

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->