### PR TITLE
fix: add app.eggObjectFactory to blacklist

### DIFF
--- a/core/dynamic-inject-runtime/test/index.test.ts
+++ b/core/dynamic-inject-runtime/test/index.test.ts
@@ -6,7 +6,7 @@ import { HelloService } from './fixtures/modules/dynamic-inject-module/HelloServ
 import { CoreTestHelper } from '../../test-util/CoreTestHelper';
 import assert from 'assert';
 
-describe('test/index.test.ts', () => {
+describe('test/dynamic-inject-runtime.test.ts', () => {
   let modules: Array<LoadUnitInstance>;
   beforeEach(async () => {
     modules = await CoreTestHelper.prepareModules([

--- a/core/metadata/src/impl/ModuleLoadUnit.ts
+++ b/core/metadata/src/impl/ModuleLoadUnit.ts
@@ -196,7 +196,7 @@ export class ModuleLoadUnit implements LoadUnit {
 
   async destroy() {
     for (const namedProtoMap of this.protoMap.values()) {
-      for (const proto of namedProtoMap.values()) {
+      for (const proto of namedProtoMap.slice()) {
         EggPrototypeFactory.instance.deletePrototype(proto, this);
       }
     }

--- a/plugin/tegg/lib/EggAppLoader.ts
+++ b/plugin/tegg/lib/EggAppLoader.ts
@@ -11,8 +11,9 @@ import { ObjectUtils } from '@eggjs/tegg-common-util';
 import { COMPATIBLE_PROTO_IMPLE_TYPE } from './EggCompatibleProtoImpl';
 import { BackgroundTaskHelper } from '@eggjs/tegg-background-task';
 import { EggContextObjectFactory, EggSingletonObjectFactory } from '@eggjs/tegg-dynamic-inject-runtime';
-const DEFAULT_APP_CLAZZ = [];
 
+const APP_CLAZZ_BLACK_LIST = [ 'eggObjectFactory' ];
+const DEFAULT_APP_CLAZZ = [];
 const DEFAULT_CONTEXT_CLAZZ = [
   'user',
 ];
@@ -111,10 +112,12 @@ export class EggAppLoader implements Loader {
     const appProperties = ObjectUtils.getProperties(app);
     const contextProperties = ObjectUtils.getProperties((app as any).context);
     // custom plugin may define property conflict with default list
-    const allSingletonClazzNames = Array.from(new Set([
+    const allSingletonClazzNameSet = new Set([
       ...appProperties,
       ...DEFAULT_APP_CLAZZ,
-    ]));
+    ]);
+    APP_CLAZZ_BLACK_LIST.forEach(t => allSingletonClazzNameSet.delete(t));
+    const allSingletonClazzNames = Array.from(allSingletonClazzNameSet);
     const allContextClazzNames = Array.from(new Set([
       ...contextProperties,
       ...DEFAULT_CONTEXT_CLAZZ,

--- a/plugin/tegg/test/DynamicInject.test.ts
+++ b/plugin/tegg/test/DynamicInject.test.ts
@@ -25,7 +25,7 @@ describe('test/DynamicInject.test.ts', () => {
     await app.ready();
   });
 
-  it('background task should work', async () => {
+  it('dynamic inject should work', async () => {
     app.mockCsrf();
     const res = await app.httpRequest()
       .get('/dynamicInject')
@@ -35,6 +35,17 @@ describe('test/DynamicInject.test.ts', () => {
       'hello, bar(context:0)',
       'hello, foo(singleton:0)',
       'hello, bar(singleton:0)',
+    ]);
+  });
+
+  it('singleton dynamic inject should work', async () => {
+    app.mockCsrf();
+    const res = await app.httpRequest()
+      .get('/singletonDynamicInject')
+      .expect(200);
+    assert.deepStrictEqual(res.body, [
+      'hello, foo(singleton:1)',
+      'hello, bar(singleton:1)',
     ]);
   });
 });

--- a/plugin/tegg/test/fixtures/apps/dynamic-inject-app/app/controller/app.ts
+++ b/plugin/tegg/test/fixtures/apps/dynamic-inject-app/app/controller/app.ts
@@ -1,9 +1,17 @@
 import { Controller } from 'egg';
 import { HelloService } from '../../modules/dynamic-inject-module/HelloService';
+import { SingletonHelloService } from '../../modules/dynamic-inject-module/SingletonHelloService';
 
 export default class App extends Controller {
   async dynamicInject() {
     const helloService: HelloService = await (this.ctx.module as any).dynamicInjectModule.helloService;
+    const msgs = await helloService.hello();
+    this.ctx.status = 200;
+    this.ctx.body = msgs;
+  }
+
+  async singletonDynamicInject() {
+    const helloService: SingletonHelloService = await (this.app.module as any).dynamicInjectModule.singletonHelloService;
     const msgs = await helloService.hello();
     this.ctx.status = 200;
     this.ctx.body = msgs;

--- a/plugin/tegg/test/fixtures/apps/dynamic-inject-app/app/router.ts
+++ b/plugin/tegg/test/fixtures/apps/dynamic-inject-app/app/router.ts
@@ -2,4 +2,5 @@ import { Application } from 'egg';
 
 module.exports = (app: Application) => {
   app.router.get('/dynamicInject', app.controller.app.dynamicInject);
+  app.router.get('/singletonDynamicInject', app.controller.app.singletonDynamicInject);
 };

--- a/plugin/tegg/test/fixtures/apps/dynamic-inject-app/modules/dynamic-inject-module/SingletonHelloService.ts
+++ b/plugin/tegg/test/fixtures/apps/dynamic-inject-app/modules/dynamic-inject-module/SingletonHelloService.ts
@@ -1,0 +1,20 @@
+import { AccessLevel, Inject, EggObjectFactory, SingletonProto } from '@eggjs/tegg';
+import { SingletonHelloType } from './FooType';
+import { AbstractSingletonHello } from './AbstractSingletonHello';
+
+@SingletonProto({
+  accessLevel: AccessLevel.PUBLIC,
+})
+export class SingletonHelloService {
+  @Inject()
+  private readonly eggObjectFactory: EggObjectFactory;
+
+  async hello(): Promise<string[]> {
+    const helloImpls = await Promise.all([
+      this.eggObjectFactory.getEggObject(AbstractSingletonHello, SingletonHelloType.FOO),
+      this.eggObjectFactory.getEggObject(AbstractSingletonHello, SingletonHelloType.BAR),
+    ]);
+    const msgs = helloImpls.map(helloImpl => helloImpl.hello());
+    return msgs;
+  }
+}


### PR DESCRIPTION
app.eggObjectFactory conflict with dynamic-inject plugin

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->