### PR TITLE
fix: should clear object promise map

### DIFF
--- a/core/runtime/src/model/AbstractEggContext.ts
+++ b/core/runtime/src/model/AbstractEggContext.ts
@@ -60,6 +60,9 @@ export abstract class AbstractEggContext implements EggContext {
         protoObjPromiseMap.set(name, objPromise);
         const obj = await objPromise;
         protoObjPromiseMap.delete(name);
+        if (!protoObjPromiseMap.size) {
+          this.eggObjectPromiseMap.delete(proto.id); 
+        }
         protoObjMap.set(name, obj);
       } else {
         await protoObjPromiseMap.get(name);

--- a/core/runtime/src/model/AbstractEggContext.ts
+++ b/core/runtime/src/model/AbstractEggContext.ts
@@ -61,7 +61,7 @@ export abstract class AbstractEggContext implements EggContext {
         const obj = await objPromise;
         protoObjPromiseMap.delete(name);
         if (!protoObjPromiseMap.size) {
-          this.eggObjectPromiseMap.delete(proto.id); 
+          this.eggObjectPromiseMap.delete(proto.id);
         }
         protoObjMap.set(name, obj);
       } else {

--- a/core/runtime/test/EggObject.test.ts
+++ b/core/runtime/test/EggObject.test.ts
@@ -28,6 +28,22 @@ describe('test/EggObject.test.ts', () => {
           'destroy',
         ]);
       });
+
+      it('should clear eggObjectMap/eggObjectPromiseMap/contextData after destroy', async () => {
+        const instance = await TestUtil.createLoadUnitInstance('lifecycle-hook');
+        const ctx = new EggTestContext();
+        const fooProto = EggPrototypeFactory.instance.getPrototype('foo');
+        const fooObj = await EggContainerFactory.getOrCreateEggObject(fooProto, fooProto.name, ctx);
+        assert(fooObj.obj);
+        await ctx.destroy({});
+        await TestUtil.destroyLoadUnitInstance(instance);
+
+        // should clear all maps
+        const assertCtx = ctx as any;
+        assert(!assertCtx.eggObjectMap.size);
+        assert(!assertCtx.eggObjectPromiseMap.size);
+        assert(!assertCtx.contextData.size);
+      });
     });
 
     describe('singleton proto', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

应该将 eggObjectPromiseMap 里的 Map 也清理掉，减少内存占用

##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->