### PR TITLE
fix: set default cwd for readModuleReference

### DIFF
--- a/core/common-util/src/ModuleConfig.ts
+++ b/core/common-util/src/ModuleConfig.ts
@@ -58,7 +58,7 @@ export class ModuleConfigUtil {
     const configDir = path.join(baseDir, 'config');
     const moduleJsonPath = path.join(configDir, 'module.json');
     if (fs.existsSync(moduleJsonPath)) {
-      return this.readModuleReferenceFromModuleJson(configDir, moduleJsonPath, options?.cwd);
+      return this.readModuleReferenceFromModuleJson(configDir, moduleJsonPath, options?.cwd || baseDir);
     }
     return this.readModuleReferenceFromScan(baseDir, options);
   }


### PR DESCRIPTION
If process.cwd is not app base dir,it will failed.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->