### PR TITLE
fix: use getMetaData for ModelMetadataUtil

### DIFF
--- a/core/orm-decorator/src/util/ModelMetadataUtil.ts
+++ b/core/orm-decorator/src/util/ModelMetadataUtil.ts
@@ -9,6 +9,6 @@ export class ModelMetadataUtil {
   }
 
   static getModelMetadata(clazz): ModelMetadata | undefined {
-    return MetadataUtil.getOwnMetaData(MODEL_METADATA, clazz);
+    return MetadataUtil.getMetaData(MODEL_METADATA, clazz);
   }
 }


### PR DESCRIPTION
In inject mode, the child class has no metadata.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->