### PR TITLE
ci: fix orm ut in node18 with macos

### DIFF
--- a/plugin/orm/test/fixtures/apps/orm-app/config/config.default.js
+++ b/plugin/orm/test/fixtures/apps/orm-app/config/config.default.js
@@ -11,7 +11,7 @@ module.exports = function() {
     orm: {
       client: 'mysql',
       database: 'test',
-      host: 'localhost',
+      host: '127.0.0.1',
       port: 3306,
       user: 'root',
 


### PR DESCRIPTION
dns lookup with node18 perfer ipv6,localhost
will be resolved to ::1, and mysql listen
bind to 127.0.0.1. It will cause conn refused.
So use 127.0.0.1 instead of localhost.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->