### PR TITLE
fix: ctx.beginModuleScope should set ctxStorage before teggCtx init

### DIFF
--- a/plugin/tegg/app/extend/context.ts
+++ b/plugin/tegg/app/extend/context.ts
@@ -11,6 +11,8 @@ export interface TEggPluginContext extends Context {
 
 export default {
   async beginModuleScope(this: TEggPluginContext, func: () => Promise<void>) {
+    // Calling by specific ctx should set ctxStorage before teggCtx init
+    this.app.ctxStorage.enterWith(this);
     await ctxLifecycleMiddleware(this, func);
   },
 

--- a/plugin/tegg/app/extend/context.ts
+++ b/plugin/tegg/app/extend/context.ts
@@ -12,8 +12,9 @@ export interface TEggPluginContext extends Context {
 export default {
   async beginModuleScope(this: TEggPluginContext, func: () => Promise<void>) {
     // Calling by specific ctx should set ctxStorage before teggCtx init
-    this.app.ctxStorage.enterWith(this);
-    await ctxLifecycleMiddleware(this, func);
+    await this.app.ctxStorage.run(this, async () => {
+      return await ctxLifecycleMiddleware(this, func);
+    });
   },
 
   get teggContext(): EggContext {

--- a/plugin/tegg/test/BackgroundTask.test.ts
+++ b/plugin/tegg/test/BackgroundTask.test.ts
@@ -3,7 +3,6 @@ import assert from 'assert';
 import path from 'path';
 import { CountService } from './fixtures/apps/background-app/modules/multi-module-background/CountService';
 import sleep from 'mz-modules/sleep';
-import fs from 'fs';
 
 describe('test/BackgroundTask.test.ts', () => {
   const appDir = path.join(__dirname, 'fixtures/apps/background-app');
@@ -42,13 +41,13 @@ describe('test/BackgroundTask.test.ts', () => {
   });
 
   it('background timeout with humanize error info', async () => {
+    app.mockLog();
     app.mockCsrf();
     await app.httpRequest()
       .get('/backgroudTimeout')
       .expect(200);
 
     await sleep(7000);
-    const errorLog = fs.readFileSync(path.resolve(appDir, 'logs/egg-app/common-error.log'), 'utf-8');
-    assert(errorLog.includes('Can not read property `testObj` because egg ctx has been destroyed ['));
+    app.expectLog('Can not read property `testObj` because egg ctx has been destroyed [');
   });
 });

--- a/plugin/tegg/test/app/extend/context.test.ts
+++ b/plugin/tegg/test/app/extend/context.test.ts
@@ -39,4 +39,16 @@ describe('test/app/extend/context.test.ts', () => {
       });
     });
   });
+
+  describe('beginModuleScope', () => {
+    it('should work', async () => {
+      const ctx = app.createAnonymousContext();
+      await assert.doesNotThrow(async () => {
+        await ctx.beginModuleScope(async () => {
+          const appService = await ctx.getEggObject(AppService);
+          assert(appService instanceof AppService);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->