### PR TITLE
fix: remove useless init singleton proto

### DIFF
--- a/plugin/tegg/lib/EggContextCompatibleHook.ts
+++ b/plugin/tegg/lib/EggContextCompatibleHook.ts
@@ -7,7 +7,6 @@ import { ROOT_PROTO } from '@eggjs/egg-module-common';
 export class EggContextCompatibleHook implements LifecycleHook<EggContextLifecycleContext, EggContext> {
   private readonly moduleHandler: ModuleHandler;
   private requestProtoList: Array<EggPrototype> = [];
-  private initProtoList: Array<EggPrototype> = [];
 
   constructor(moduleHandler: ModuleHandler) {
     this.moduleHandler = moduleHandler;
@@ -16,8 +15,6 @@ export class EggContextCompatibleHook implements LifecycleHook<EggContextLifecyc
       for (const proto of iterator) {
         if (proto.initType === ObjectInitType.CONTEXT) {
           this.requestProtoList.push(proto);
-        } else if (proto.initType === ObjectInitType.SINGLETON) {
-          this.initProtoList.push(proto);
         }
       }
     }
@@ -29,9 +26,6 @@ export class EggContextCompatibleHook implements LifecycleHook<EggContextLifecyc
       for (const proto of this.requestProtoList) {
         ctx.addProtoToCreate(proto.name, proto);
       }
-      await Promise.all(this.initProtoList.map(async proto => {
-        await EggContainerFactory.getOrCreateEggObject(proto);
-      }));
     } else {
       // Use for ctx.runInBackground.
       // BackgroundTaskHelper should get by sync,


### PR DESCRIPTION
All ctx proto has been init, so trigger singleton
proto init is useless.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->