### PR TITLE
fix: ensure ContextInitiator be called after ctx ready

### DIFF
--- a/plugin/controller/test/fixtures/apps/controller-app/app/controller/MiddlewareController.ts
+++ b/plugin/controller/test/fixtures/apps/controller-app/app/controller/MiddlewareController.ts
@@ -8,6 +8,7 @@ import {
 import AppService from '../../modules/multi-module-service/AppService';
 import { countMw } from '../middleware/count_mw';
 import { logMwFactory } from '../middleware/log_mw';
+import { callModuleCtx } from '../middleware/call_module';
 
 @HTTPController({
   path: '/middleware',
@@ -31,6 +32,15 @@ export class MiddlewareController {
   })
   @Middleware(logMwFactory('use middleware'))
   async middleware() {
+    return {};
+  }
+
+  @HTTPMethod({
+    method: HTTPMethodEnum.GET,
+    path: '/methodCallModule',
+  })
+  @Middleware(callModuleCtx)
+  async middlewareCallModule() {
     return {};
   }
 }

--- a/plugin/controller/test/fixtures/apps/controller-app/app/middleware/call_module.ts
+++ b/plugin/controller/test/fixtures/apps/controller-app/app/middleware/call_module.ts
@@ -1,0 +1,7 @@
+import { Context } from 'egg';
+import { Next } from '@eggjs/tegg';
+
+export async function callModuleCtx(ctx: Context, next: Next) {
+  await (ctx.module as any).multiModuleService.appService.findApp('foo');
+  await next();
+}

--- a/plugin/controller/test/http/middleware.test.ts
+++ b/plugin/controller/test/http/middleware.test.ts
@@ -48,4 +48,11 @@ describe('test/middleware.test.ts', () => {
         assert(res.body.log === 'use middleware');
       });
   });
+
+  it('method middleware call module should work', async () => {
+    app.mockCsrf();
+    await app.httpRequest()
+      .get('/middleware/methodCallModule')
+      .expect(200);
+  });
 });

--- a/plugin/tegg/lib/EggContextCompatibleHook.ts
+++ b/plugin/tegg/lib/EggContextCompatibleHook.ts
@@ -35,4 +35,12 @@ export class EggContextCompatibleHook implements LifecycleHook<EggContextLifecyc
       await EggContainerFactory.getOrCreateEggObject(protoObj as EggPrototype);
     }
   }
+
+  async postCreate(_, ctx: EggContext): Promise<void> {
+    const rootProto = ctx.get(ROOT_PROTO);
+    if (rootProto) {
+      // Ensure ContextInitiator be called.
+      await EggContainerFactory.getOrCreateEggObject(rootProto as EggPrototype);
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->