### PR TITLE
fix: add missing deps on @eggjs/tegg-aop-plugin

### DIFF
--- a/plugin/aop/lib/AopContextHook.ts
+++ b/plugin/aop/lib/AopContextHook.ts
@@ -1,7 +1,7 @@
 import type { Application } from 'egg';
 import type { EggContext, EggContextLifecycleContext } from '@eggjs/tegg-runtime';
-import type { EggProtoImplClass, LifecycleHook, ObjectInitType } from '@eggjs/tegg';
-import { PrototypeUtil } from '@eggjs/tegg';
+import type { EggProtoImplClass, LifecycleHook } from '@eggjs/tegg';
+import { PrototypeUtil, ObjectInitType } from '@eggjs/tegg';
 import { AspectInfoUtil } from '@eggjs/aop-decorator';
 import { EggPrototype, TeggError } from '@eggjs/tegg-metadata';
 import { ROOT_PROTO } from '@eggjs/egg-module-common';

--- a/plugin/aop/lib/AopContextHook.ts
+++ b/plugin/aop/lib/AopContextHook.ts
@@ -1,6 +1,7 @@
-import { Application } from 'egg';
-import { EggProtoImplClass, LifecycleHook, ObjectInitType, PrototypeUtil } from '@eggjs/tegg';
-import { EggContext, EggContextLifecycleContext } from '@eggjs/tegg-runtime';
+import type { Application } from 'egg';
+import type { EggContext, EggContextLifecycleContext } from '@eggjs/tegg-runtime';
+import type { EggProtoImplClass, LifecycleHook, ObjectInitType } from '@eggjs/tegg';
+import { PrototypeUtil } from '@eggjs/tegg';
 import { AspectInfoUtil } from '@eggjs/aop-decorator';
 import { EggPrototype, TeggError } from '@eggjs/tegg-metadata';
 import { ROOT_PROTO } from '@eggjs/egg-module-common';

--- a/plugin/aop/package.json
+++ b/plugin/aop/package.json
@@ -43,7 +43,10 @@
   },
   "dependencies": {
     "@eggjs/tegg": "^3.14.3",
-    "@eggjs/tegg-aop-runtime": "^3.14.3"
+    "@eggjs/tegg-aop-runtime": "^3.14.3",
+    "@eggjs/aop-decorator": "^3.14.3",
+    "@eggjs/tegg-metadata": "^3.14.3",
+    "@eggjs/egg-module-common": "^3.14.3"
   },
   "devDependencies": {
     "@eggjs/tegg-config": "^3.14.3",


### PR DESCRIPTION
```
node_modules/@eggjs/tegg-aop-plugin/app.js, error: Cannot find module '@eggjs/aop-decorator'
Require stack:
- ~/node_modules/@eggjs/tegg-aop-plugin/lib/AopContextHook.js
```