### PR TITLE
feat: inject moduleConfig read from tegg-config app.moduleConfigs config

### DIFF
--- a/plugin/tegg/lib/ModuleConfigLoader.ts
+++ b/plugin/tegg/lib/ModuleConfigLoader.ts
@@ -49,7 +49,8 @@ export class ModuleConfigLoader {
     const moduleConfigMap: Record<string, ModuleConfigHolder> = {};
     for (const reference of this.app.moduleReferences) {
       const moduleName = ModuleConfigUtil.readModuleNameSync(reference.path);
-      const config = ModuleConfigUtil.loadModuleConfigSync(reference.path, undefined, this.app.config.env) || {};
+      // first read @eggjs/tegg-config moduleConfigs
+      const config = this.app.moduleConfigs[moduleName].config || ModuleConfigUtil.loadModuleConfigSync(reference.path, undefined, this.app.config.env) || {};
       moduleConfigMap[moduleName] = {
         name: moduleName,
         reference: {

--- a/plugin/tegg/lib/ModuleConfigLoader.ts
+++ b/plugin/tegg/lib/ModuleConfigLoader.ts
@@ -13,6 +13,7 @@ import {
 import { ModuleConfigUtil } from '@eggjs/tegg/helper';
 import { COMPATIBLE_PROTO_IMPLE_TYPE } from './EggCompatibleProtoImpl';
 import { Application } from 'egg';
+import extend from 'extend2';
 
 export class ModuleConfigLoader {
   constructor(readonly app: Application) {
@@ -49,8 +50,9 @@ export class ModuleConfigLoader {
     const moduleConfigMap: Record<string, ModuleConfigHolder> = {};
     for (const reference of this.app.moduleReferences) {
       const moduleName = ModuleConfigUtil.readModuleNameSync(reference.path);
-      // first read @eggjs/tegg-config moduleConfigs
-      const config = this.app.moduleConfigs[moduleName].config || ModuleConfigUtil.loadModuleConfigSync(reference.path, undefined, this.app.config.env) || {};
+      const defaultConfig = ModuleConfigUtil.loadModuleConfigSync(reference.path, undefined, this.app.config.env);
+      // @eggjs/tegg-config moduleConfigs[module].config overwrite
+      const config = extend(true, {}, defaultConfig, this.app.moduleConfigs[moduleName]?.config);
       moduleConfigMap[moduleName] = {
         name: moduleName,
         reference: {

--- a/plugin/tegg/package.json
+++ b/plugin/tegg/package.json
@@ -53,6 +53,7 @@
     "@eggjs/tegg-loader": "^3.27.0",
     "@eggjs/tegg-metadata": "^3.27.0",
     "@eggjs/tegg-runtime": "^3.27.0",
+    "extend2": "^1.0.0",
     "sdk-base": "^4.2.0"
   },
   "devDependencies": {

--- a/plugin/tegg/test/ModuleConfig.test.ts
+++ b/plugin/tegg/test/ModuleConfig.test.ts
@@ -37,4 +37,18 @@ describe('test/ModuleConfig.test.ts', () => {
         });
       });
   });
+
+  it('should work with overwrite', async () => {
+    mm(app.moduleConfigs.simple.config, 'features', { dynamic: { foo: 'bar', bar: 'overwrite foo' } });
+
+    await app.httpRequest()
+      .get('/config')
+      .expect(200)
+      .expect(res => {
+        assert.deepStrictEqual(res.body, {
+          moduleConfigs: { features: { dynamic: { foo: 'bar', bar: 'overwrite foo' } } },
+          moduleConfig: { features: { dynamic: { foo: 'bar', bar: 'overwrite foo' } } },
+        });
+      });
+  });
 });

--- a/plugin/tegg/test/ModuleConfig.test.ts
+++ b/plugin/tegg/test/ModuleConfig.test.ts
@@ -42,7 +42,7 @@ describe('test/ModuleConfig.test.ts', () => {
     mm(app.moduleConfigs.simple.config, 'features', { dynamic: { foo: 'bar', bar: 'overwrite foo' } });
 
     await app.httpRequest()
-      .get('/config')
+      .get('/overwrite_config')
       .expect(200)
       .expect(res => {
         assert.deepStrictEqual(res.body, {

--- a/plugin/tegg/test/fixtures/apps/inject-module-config/app.ts
+++ b/plugin/tegg/test/fixtures/apps/inject-module-config/app.ts
@@ -1,0 +1,15 @@
+import { Application } from 'egg';
+
+export default class AppBoot {
+  app: Application;
+
+  constructor(app: Application) {
+    this.app = app;
+  }
+
+  configWillLoad() {
+    if (this.app.moduleConfigs?.overwrite?.config) {
+      (this.app.moduleConfigs.overwrite.config as Record<string, any>).features.dynamic.bar = 'overwrite foo';
+    }
+  }
+}

--- a/plugin/tegg/test/fixtures/apps/inject-module-config/app/controller/app.ts
+++ b/plugin/tegg/test/fixtures/apps/inject-module-config/app/controller/app.ts
@@ -5,4 +5,9 @@ export default class App extends Controller {
     const configs = await this.ctx.module.simple.foo.getConfig();
     this.ctx.body = configs;
   }
+
+  async overwriteConfig() {
+    const configs = await this.ctx.module.overwrite.bar.getConfig();
+    this.ctx.body = configs;
+  }
 }

--- a/plugin/tegg/test/fixtures/apps/inject-module-config/app/router.ts
+++ b/plugin/tegg/test/fixtures/apps/inject-module-config/app/router.ts
@@ -2,4 +2,5 @@ import { Application } from 'egg';
 
 module.exports = (app: Application) => {
   app.router.get('/config', app.controller.app.baseDir);
+  app.router.get('/overwrite_config', app.controller.app.overwriteConfig);
 };

--- a/plugin/tegg/test/fixtures/apps/inject-module-config/app/typings/index.d.ts
+++ b/plugin/tegg/test/fixtures/apps/inject-module-config/app/typings/index.d.ts
@@ -1,10 +1,14 @@
 import 'egg';
 import { Foo } from '../../modules/module-with-config/foo';
+import { Bar } from '../../modules/module-with-overwrite-config/bar';
 
 declare module 'egg' {
   export interface EggModule {
     simple: {
       foo: Foo;
-    }
+    },
+    overwrite: {
+      bar: Bar;
+    },
   }
 }

--- a/plugin/tegg/test/fixtures/apps/inject-module-config/modules/module-with-overwrite-config/bar.ts
+++ b/plugin/tegg/test/fixtures/apps/inject-module-config/modules/module-with-overwrite-config/bar.ts
@@ -1,0 +1,19 @@
+import { AccessLevel, ContextProto, Inject, ModuleConfigs } from '@eggjs/tegg';
+
+@ContextProto({
+  accessLevel: AccessLevel.PUBLIC,
+})
+export class Bar {
+  @Inject()
+  moduleConfigs: ModuleConfigs;
+
+  @Inject()
+  moduleConfig: Record<string, any>;
+
+  async getConfig(): Promise<object> {
+    return {
+      moduleConfigs: this.moduleConfigs.get('overwrite'),
+      moduleConfig: this.moduleConfig,
+    };
+  }
+}

--- a/plugin/tegg/test/fixtures/apps/inject-module-config/modules/module-with-overwrite-config/module.unittest.yml
+++ b/plugin/tegg/test/fixtures/apps/inject-module-config/modules/module-with-overwrite-config/module.unittest.yml
@@ -1,0 +1,3 @@
+features:
+  dynamic:
+    bar: 'foo'

--- a/plugin/tegg/test/fixtures/apps/inject-module-config/modules/module-with-overwrite-config/module.yml
+++ b/plugin/tegg/test/fixtures/apps/inject-module-config/modules/module-with-overwrite-config/module.yml
@@ -1,0 +1,3 @@
+features:
+  dynamic:
+    foo: 'bar'

--- a/plugin/tegg/test/fixtures/apps/inject-module-config/modules/module-with-overwrite-config/package.json
+++ b/plugin/tegg/test/fixtures/apps/inject-module-config/modules/module-with-overwrite-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "overwrite",
+  "eggModule": {
+    "name": "overwrite"
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
- `@eggjs/tegg-plugin`
- `@eggjs/tegg-config`

##### Description of change
<!-- Provide a description of the change below this comment. -->
module.yml/json 存放一些敏感配置 例如 db password（kms:encodepassword....），我们需要在应用启动前将其配置解密还原成明文数据字段

目前看到的注入点 app.moduleConfigs，所以需要 inject moduleConfig 优先读取 app.moduleConfigs 数据对象，确保服务在注入的时候拿到的是解密后配置

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->