### PR TITLE
chore: import hookNames from package exports

### DIFF
--- a/plugin/orm/lib/LeoricRegister.ts
+++ b/plugin/orm/lib/LeoricRegister.ts
@@ -1,8 +1,7 @@
 import Base from 'sdk-base';
 import { ModelProtoManager } from './ModelProtoManager';
 import { DataSourceManager, OrmConfig } from './DataSourceManager';
-import Realm from 'leoric';
-import { hookNames } from 'leoric/lib/setup_hooks';
+import Realm, { hookNames } from 'leoric';
 import { ModelMetadata, ModelMetadataUtil } from '@eggjs/tegg-orm-decorator';
 
 export class LeoricRegister extends Base {

--- a/plugin/orm/package.json
+++ b/plugin/orm/package.json
@@ -58,7 +58,7 @@
     "@eggjs/tegg-runtime": "^3.28.0",
     "@types/koa-router": "^7.0.40",
     "koa-compose": "^3.2.1",
-    "leoric": "^2.11.5",
+    "leoric": "^2.12.2",
     "sdk-base": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
- plugin/orm


##### Description of change
- changed the imported `hookNames` from internal module path to package named exports