### PR TITLE
chore: add type for adviceParams

### DIFF
--- a/core/aop-decorator/src/decorator/Pointcut.ts
+++ b/core/aop-decorator/src/decorator/Pointcut.ts
@@ -4,17 +4,17 @@ import { PointcutAdviceInfoUtil } from '../util/PointcutAdviceInfoUtil';
 import assert from 'assert';
 import { AdviceInfoUtil } from '../util/AdviceInfoUtil';
 
-export interface PointcutOptions {
+export interface PointcutOptions<K = any> {
   // default is 1000
   order?: number;
-  adviceParams?: any;
+  adviceParams?: K;
 }
 
 const defaultPointcutOptions = {
   order: 1000,
 };
 
-export function Pointcut(adviceClazz: EggProtoImplClass<IAdvice>, options?: PointcutOptions) {
+export function Pointcut<T extends object, K = any>(adviceClazz: EggProtoImplClass<IAdvice<T, K>>, options?: PointcutOptions<K>) {
   return function(target: any, propertyKey: PropertyKey) {
     assert(AdviceInfoUtil.isAdvice(adviceClazz), `class ${adviceClazz} has no @Advice decorator`);
     const targetClazz = target.constructor as EggProtoImplClass;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

使用 AOP Pointcut 时 adviceParams 参数类型是 any，体验不好，尝试加上了类型。

修改后可能会导致部分用户代码出现类型报错。

When using AOP Pointcut, the adviceParams parameter is any. The experience is not good, so I tried adding it.

Modification may cause type errors to occur in some user codes.

##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->