### PR TITLE
feat: add getEggObjects API to fetch all instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,7 +953,7 @@ export class HelloService {
   private readonly eggObjectFactory: EggObjectFactory;
 
   async hello(): Promise<string[]> {
-    const helloImpls = await this.eggObjectFactory.getEggObjects(AbstractHello, HelloType.BAR);
+    const helloImpls = await this.eggObjectFactory.getEggObjects(AbstractHello);
     const messages = [];
     for await (const helloImpl of helloImpls) {
       messages.push(helloImpl.hello());

--- a/README.md
+++ b/README.md
@@ -934,10 +934,31 @@ import { EggObjectFactory } from '@eggjs/tegg';
 export class HelloService {
   @Inject()
   private readonly eggObjectFactory: EggObjectFactory;
-  
+
   async hello(): Promise<string> {
     const helloImpl = await this.eggObjectFactory.getEggObject(AbstractHello, HelloType.BAR);
     return helloImpl.hello();
+  }
+}
+```
+
+动态获取多个实现，通过 for/await 循环获得实例。
+
+```ts
+import { EggObjectFactory } from '@eggjs/tegg';
+
+@ContextProto()
+export class HelloService {
+  @Inject()
+  private readonly eggObjectFactory: EggObjectFactory;
+
+  async hello(): Promise<string[]> {
+    const helloImpls = await this.eggObjectFactory.getEggObjects(AbstractHello, HelloType.BAR);
+    const messages = [];
+    for await (const helloImpl of helloImpls) {
+      messages.push(helloImpl.hello());
+    }
+    return messages;
   }
 }
 ```

--- a/core/dynamic-inject-runtime/src/EggObjectFactory.ts
+++ b/core/dynamic-inject-runtime/src/EggObjectFactory.ts
@@ -1,6 +1,11 @@
 import type { EggContainerFactory } from '@eggjs/tegg-runtime';
-import { EggAbstractClazz, EggObjectFactory as IEggObjectFactory, QualifierImplUtil } from '@eggjs/tegg-dynamic-inject';
 import { AccessLevel, PrototypeUtil, QualifierValue, SingletonProto } from '@eggjs/core-decorator';
+import {
+  EggAbstractClazz,
+  EggObjectFactory as IEggObjectFactory,
+  QualifierImplUtil,
+} from '@eggjs/tegg-dynamic-inject';
+
 import { EGG_OBJECT_FACTORY_PROTO_IMPLE_TYPE } from './EggObjectFactoryPrototype';
 
 @SingletonProto({
@@ -22,5 +27,27 @@ export class EggObjectFactory implements IEggObjectFactory {
     }
     const eggObject = await this.eggContainerFactory.getOrCreateEggObject(protoObj, protoObj.name);
     return eggObject.obj as T;
+  }
+
+  async getEggObjects<T extends object>(abstractClazz: EggAbstractClazz<T>) {
+    const implClazzMap = QualifierImplUtil.getQualifierImpMap(abstractClazz);
+    const getEggObject = this.getEggObject.bind(this);
+    const qualifierValues = Array.from(implClazzMap.keys());
+
+    return {
+      [Symbol.asyncIterator]() {
+        return {
+          key: 0,
+          async next() {
+            if (this.key === qualifierValues.length) {
+              return { done: true } as IteratorResult<T>;
+            }
+
+            const value = await getEggObject(abstractClazz, qualifierValues[this.key++]);
+            return { value, done: false } as IteratorResult<T>;
+          },
+        };
+      },
+    };
   }
 }

--- a/core/dynamic-inject-runtime/test/fixtures/modules/dynamic-inject-module/HelloService.ts
+++ b/core/dynamic-inject-runtime/test/fixtures/modules/dynamic-inject-module/HelloService.ts
@@ -1,8 +1,9 @@
 import { ContextProto, Inject } from '@eggjs/core-decorator';
-import { ContextHelloType, SingletonHelloType } from './FooType';
+import { EggObjectFactory } from '@eggjs/tegg-dynamic-inject';
+
 import { AbstractContextHello } from './AbstractContextHello';
 import { AbstractSingletonHello } from './AbstractSingletonHello';
-import { EggObjectFactory } from '@eggjs/tegg-dynamic-inject';
+import { ContextHelloType, SingletonHelloType } from './FooType';
 
 @ContextProto()
 export class HelloService {
@@ -17,6 +18,21 @@ export class HelloService {
       this.eggObjectFactory.getEggObject(AbstractSingletonHello, SingletonHelloType.BAR),
     ]);
     const msgs = helloImpls.map(helloImpl => helloImpl.hello());
+    return msgs;
+  }
+
+  async sayHelloToAll(): Promise<string[]> {
+    const singletonHellos = await this.eggObjectFactory.getEggObjects(AbstractSingletonHello);
+    const contextHellos = await this.eggObjectFactory.getEggObjects(AbstractContextHello);
+
+    const msgs: string[] = [];
+    for await (const helloImpl of singletonHellos) {
+      msgs.push(helloImpl.hello());
+    }
+    for await (const helloImpl of contextHellos) {
+      msgs.push(helloImpl.hello());
+    }
+
     return msgs;
   }
 }

--- a/core/dynamic-inject-runtime/test/index.test.ts
+++ b/core/dynamic-inject-runtime/test/index.test.ts
@@ -1,10 +1,12 @@
-import path from 'path';
-import { LoadUnitInstance, LoadUnitInstanceFactory } from '@eggjs/tegg-runtime';
-import { LoadUnitFactory } from '@eggjs/tegg-metadata';
-import { EggTestContext } from '../../test-util';
-import { HelloService } from './fixtures/modules/dynamic-inject-module/HelloService';
-import { CoreTestHelper } from '../../test-util/CoreTestHelper';
 import assert from 'assert';
+import path from 'path';
+
+import { LoadUnitFactory } from '@eggjs/tegg-metadata';
+import { LoadUnitInstance, LoadUnitInstanceFactory } from '@eggjs/tegg-runtime';
+
+import { EggTestContext } from '../../test-util';
+import { CoreTestHelper } from '../../test-util/CoreTestHelper';
+import { HelloService } from './fixtures/modules/dynamic-inject-module/HelloService';
 
 describe('test/dynamic-inject-runtime.test.ts', () => {
   let modules: Array<LoadUnitInstance>;
@@ -46,5 +48,19 @@ describe('test/dynamic-inject-runtime.test.ts', () => {
         'hello, bar(singleton:1)',
       ]);
     });
+  });
+
+  it('should work with getAllEggObjects', async () => {
+    await EggTestContext.mockContext(async () => {
+      const helloService = await CoreTestHelper.getObject(HelloService);
+      const msgs = await helloService.sayHelloToAll();
+      assert.deepStrictEqual(msgs, [
+        'hello, bar(singleton:0)',
+        'hello, foo(singleton:0)',
+        'hello, bar(context:0)',
+        'hello, foo(context:0)',
+      ]);
+    });
+
   });
 });

--- a/core/dynamic-inject/src/EggObjectFactory.ts
+++ b/core/dynamic-inject/src/EggObjectFactory.ts
@@ -1,6 +1,8 @@
-import { EggAbstractClazz } from './typing';
 import { QualifierValue } from '@eggjs/core-decorator';
+
+import { EggAbstractClazz } from './typing';
 
 export interface EggObjectFactory {
   getEggObject<T extends object>(abstractClazz: EggAbstractClazz<T>, qualifierValue: QualifierValue): Promise<T>;
+  getEggObjects<T extends object>(abstractClazz: EggAbstractClazz<T>): Promise<AsyncIterable<T>>;
 }

--- a/core/dynamic-inject/src/QualifierImplUtil.ts
+++ b/core/dynamic-inject/src/QualifierImplUtil.ts
@@ -9,8 +9,14 @@ export class QualifierImplUtil {
     implMap.set(qualifierValue, implClazz);
   }
 
-  static getQualifierImp(abstractClazz: EggAbstractClazz, qualifierValue: QualifierValue):EggProtoImplClass | undefined {
+  static getQualifierImp(abstractClazz: EggAbstractClazz, qualifierValue: QualifierValue): EggProtoImplClass | undefined {
     const implMap: Map<QualifierValue, EggProtoImplClass> | undefined = MetadataUtil.getMetaData(QUALIFIER_IMPL_MAP, abstractClazz as unknown as EggProtoImplClass);
     return implMap?.get(qualifierValue);
+  }
+
+  static listQualifierImps(abstractClazz: EggAbstractClazz): EggProtoImplClass[] {
+    const implMap: Map<QualifierValue, EggProtoImplClass> | undefined = MetadataUtil.getMetaData(QUALIFIER_IMPL_MAP, abstractClazz as unknown as EggProtoImplClass);
+    if (!implMap) return [];
+    return Array.from(implMap.values());
   }
 }

--- a/core/dynamic-inject/src/QualifierImplUtil.ts
+++ b/core/dynamic-inject/src/QualifierImplUtil.ts
@@ -1,5 +1,6 @@
-import { EggAbstractClazz } from './typing';
 import { EggProtoImplClass, MetadataUtil, QualifierValue } from '@eggjs/core-decorator';
+
+import { EggAbstractClazz } from './typing';
 
 export const QUALIFIER_IMPL_MAP = Symbol.for('EggPrototype#qualifierImplMap');
 
@@ -14,9 +15,8 @@ export class QualifierImplUtil {
     return implMap?.get(qualifierValue);
   }
 
-  static listQualifierImps(abstractClazz: EggAbstractClazz): EggProtoImplClass[] {
+  static getQualifierImpMap(abstractClazz: EggAbstractClazz): Map<QualifierValue, EggProtoImplClass> {
     const implMap: Map<QualifierValue, EggProtoImplClass> | undefined = MetadataUtil.getMetaData(QUALIFIER_IMPL_MAP, abstractClazz as unknown as EggProtoImplClass);
-    if (!implMap) return [];
-    return Array.from(implMap.values());
+    return implMap || new Map();
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

新增 `eggObjectFactory.getEggObjects` 接口，用于获取抽象类对应的所有实现。

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->