### PR TITLE
fix: fix dao extension in prod

### DIFF
--- a/core/dal-runtime/src/SqlMapLoader.ts
+++ b/core/dal-runtime/src/SqlMapLoader.ts
@@ -3,6 +3,7 @@ import { TableModel, SqlMap } from '@eggjs/dal-decorator';
 import { Logger } from '@eggjs/tegg';
 import { BaseSqlMapGenerator } from './BaseSqlMap';
 import { TableSqlMap } from './TableSqlMap';
+import { LoaderUtil } from '@eggjs/tegg/helper';
 
 export class SqlMapLoader {
   private readonly logger: Logger;
@@ -10,7 +11,7 @@ export class SqlMapLoader {
   private readonly sqlMapPath: string;
 
   constructor(tableModel: TableModel, moduleDir: string, logger: Logger) {
-    this.sqlMapPath = path.join(moduleDir, 'dal/extension', `${tableModel.clazz.name}Extension.ts`);
+    this.sqlMapPath = path.join(moduleDir, 'dal/extension', `${tableModel.clazz.name}Extension${LoaderUtil.extension}`);
     this.logger = logger;
     this.tableModel = tableModel;
   }

--- a/core/loader/src/LoaderUtil.ts
+++ b/core/loader/src/LoaderUtil.ts
@@ -8,6 +8,8 @@ const Module = module.constructor.length > 1
   /* istanbul ignore next */
   : BuiltinModule;
 
+const EXTENSION = Object.keys((Module as any)._extensions).find(t => t === '.ts') ? '.ts' : '.js';
+
 interface LoaderUtilConfig {
   extraFilePattern?: string[];
 }
@@ -17,6 +19,8 @@ export class LoaderUtil {
   static setConfig(config: LoaderUtilConfig) {
     this.config = config;
   }
+
+  static extension = EXTENSION;
 
   static filePattern(): string[] {
     const extensions = Object.keys((Module as any)._extensions);

--- a/plugin/dal/lib/DataSource.ts
+++ b/plugin/dal/lib/DataSource.ts
@@ -21,6 +21,14 @@ import { EggObject, EggObjectLifeCycleContext } from '@eggjs/tegg-runtime';
 import { TableModelManager } from './TableModelManager';
 import { MysqlDataSourceManager } from './MysqlDataSourceManager';
 import { SqlMapManager } from './SqlMapManager';
+import BuiltinModule from 'module';
+
+// Guard against poorly mocked module constructors.
+const Module = module.constructor.length > 1
+  ? module.constructor
+  /* istanbul ignore next */
+  : BuiltinModule;
+const EXTENSION = Object.keys((Module as any)._extensions).find(t => t === '.ts') ? '.ts' : '.js';
 
 @MultiInstanceProto({
   accessLevel: AccessLevel.PUBLIC,
@@ -36,8 +44,7 @@ import { SqlMapManager } from './SqlMapManager';
     } catch {
       return [];
     }
-
-    const daos = dirents.filter(t => t.endsWith('DAO.ts'));
+    const daos = dirents.filter(t => t.endsWith(`DAO${EXTENSION}`));
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const daoClazzList = daos.map(t => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/plugin/dal/lib/DataSource.ts
+++ b/plugin/dal/lib/DataSource.ts
@@ -21,14 +21,7 @@ import { EggObject, EggObjectLifeCycleContext } from '@eggjs/tegg-runtime';
 import { TableModelManager } from './TableModelManager';
 import { MysqlDataSourceManager } from './MysqlDataSourceManager';
 import { SqlMapManager } from './SqlMapManager';
-import BuiltinModule from 'module';
-
-// Guard against poorly mocked module constructors.
-const Module = module.constructor.length > 1
-  ? module.constructor
-  /* istanbul ignore next */
-  : BuiltinModule;
-const EXTENSION = Object.keys((Module as any)._extensions).find(t => t === '.ts') ? '.ts' : '.js';
+import { LoaderUtil } from '@eggjs/tegg/helper';
 
 @MultiInstanceProto({
   accessLevel: AccessLevel.PUBLIC,
@@ -44,7 +37,7 @@ const EXTENSION = Object.keys((Module as any)._extensions).find(t => t === '.ts'
     } catch {
       return [];
     }
-    const daos = dirents.filter(t => t.endsWith(`DAO${EXTENSION}`));
+    const daos = dirents.filter(t => t.endsWith(`DAO${LoaderUtil.extension}`));
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const daoClazzList = daos.map(t => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved robustness in module constructor handling to dynamically determine and filter data access objects based on file extensions.
	- Modified path construction logic for loading SQL maps to include the determined file extension.
	- Introduced constant for file extension and updated `LoaderUtil` class to include a static property for holding this value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->