### PR TITLE
fix: disable dump in preload

### DIFF
--- a/standalone/standalone/src/Runner.ts
+++ b/standalone/standalone/src/Runner.ts
@@ -210,6 +210,7 @@ export class Runner {
     await EggModuleLoader.preLoad(moduleReferences, {
       baseDir: cwd,
       logger: console,
+      dump: false,
     });
   }
 

--- a/standalone/standalone/test/index.test.ts
+++ b/standalone/standalone/test/index.test.ts
@@ -299,6 +299,9 @@ describe('standalone/standalone/test/index.test.ts', () => {
     let Foo;
 
     beforeEach(() => {
+      mm.restore();
+      mm.spy(ModuleDescriptorDumper, 'dump');
+
       delete require.cache[require.resolve(path.join(fixturePath, './foo'))];
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       Foo = require(path.join(fixturePath, './foo')).Foo;
@@ -315,6 +318,7 @@ describe('standalone/standalone/test/index.test.ts', () => {
         'postInject',
         'init',
       ]);
+      assert.equal((ModuleDescriptorDumper.dump as any).called, 1);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced loading and initialization processes for the Runner class, improving functionality.
	- Added error handling for better stability during execution.

- **Bug Fixes**
	- Improved error logging during the context destruction phase.

- **Tests**
	- Added assertions to verify the behavior of the ModuleDescriptorDumper in test cases, ensuring correct invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->