### PR TITLE
feat: add timeout metadata for http controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,7 +968,6 @@ import { ContextHelloType } from '../FooType';
 import { AbstractContextHello } from '../AbstractHello';
 
 @ContextProto()
-// 需要注意的是，对应枚举如果已经被实现，则会报错，若你已经知晓此情况，想覆盖此枚举类型，则增加参数 true 来强制覆盖，例：@Hello(HelloType.BAR, true)
 @Hello(HelloType.BAR)
 export class BarHello extends AbstractHello {
   hello(): string {

--- a/core/common-util/src/TimerUtil.ts
+++ b/core/common-util/src/TimerUtil.ts
@@ -1,5 +1,32 @@
+class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TimeoutError';
+  }
+}
+
 export class TimerUtil {
+  static TimeoutError = TimeoutError;
+
   static async sleep(ms: number) {
     await new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  static async timeout<T>(fn: () => Promise<T>, ms?: number): Promise<T> {
+    if (!ms) {
+      return await fn();
+    }
+
+    let timer: NodeJS.Timeout;
+    const promise = new Promise<T>((resolve, reject) => {
+      timer = setTimeout(() => reject(new TimeoutError('timeout')), ms);
+      fn().then(resolve).catch(reject);
+    });
+
+    return await promise.finally(() => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    });
   }
 }

--- a/core/common-util/test/TimerUtil.test.ts
+++ b/core/common-util/test/TimerUtil.test.ts
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import { strict as assert } from 'node:assert';
 import { TimerUtil } from '..';
 
 describe('test/TimerUtil.test.ts', () => {
@@ -7,5 +7,31 @@ describe('test/TimerUtil.test.ts', () => {
     await TimerUtil.sleep(3);
     const use = Date.now() - start;
     assert(use > 1, `use time ${use}ms`);
+  });
+
+  describe('timeout', () => {
+    const fixture = Symbol.for('timeout#res');
+    const delay = (ms: number) => () => new Promise(resolve => setTimeout(() => resolve(fixture), ms));
+
+    it('should work without ms', async () => {
+      const res = await TimerUtil.timeout(delay(50));
+      assert.equal(res, fixture);
+    });
+
+    it('should work with ms', async () => {
+      const res = await TimerUtil.timeout(delay(50), 100);
+      assert.equal(res, fixture);
+    });
+
+    it('should timeout', async () => {
+      await assert.rejects(TimerUtil.timeout(delay(100), 50), (e: any) => {
+        return e instanceof TimerUtil.TimeoutError && e.message === 'timeout';
+      });
+    });
+
+    it('should throw error', async () => {
+      const e = new Error('test');
+      await assert.rejects(TimerUtil.timeout(async () => { throw e; }, 100), (err: any) => err === e);
+    });
   });
 });

--- a/core/controller-decorator/src/decorator/http/HTTPController.ts
+++ b/core/controller-decorator/src/decorator/http/HTTPController.ts
@@ -11,6 +11,9 @@ export function HTTPController(param?: HTTPControllerParams) {
     if (param?.controllerName) {
       ControllerInfoUtil.setControllerName(constructor, param.controllerName);
     }
+    if (param?.timeout) {
+      ControllerInfoUtil.setControllerTimeout(param.timeout, constructor);
+    }
     if (param?.path) {
       HTTPInfoUtil.setHTTPPath(param.path, constructor);
     }

--- a/core/controller-decorator/src/decorator/http/HTTPMethod.ts
+++ b/core/controller-decorator/src/decorator/http/HTTPMethod.ts
@@ -13,6 +13,9 @@ export function HTTPMethod(param: HTTPMethodParams) {
     MethodInfoUtil.setMethodControllerType(controllerClazz, methodName, ControllerType.HTTP);
     HTTPInfoUtil.setHTTPMethodPath(param.path, controllerClazz, methodName);
     HTTPInfoUtil.setHTTPMethodMethod(param.method, controllerClazz, methodName);
+    if (param.timeout) {
+      MethodInfoUtil.setMethodTimeout(param.timeout, controllerClazz, methodName);
+    }
     if (param.priority !== undefined) {
       HTTPInfoUtil.setHTTPMethodPriority(param.priority, controllerClazz, methodName);
     }

--- a/core/controller-decorator/src/impl/http/HTTPControllerMetaBuilder.ts
+++ b/core/controller-decorator/src/impl/http/HTTPControllerMetaBuilder.ts
@@ -46,8 +46,9 @@ export class HTTPControllerMetaBuilder {
     const needAcl = ControllerInfoUtil.hasControllerAcl(this.clazz);
     const aclCode = ControllerInfoUtil.getControllerAcl(this.clazz);
     const hosts = ControllerInfoUtil.getControllerHosts(this.clazz);
+    const timeout = ControllerInfoUtil.getControllerTimeout(this.clazz);
     const metadata = new HTTPControllerMeta(
-      clazzName, protoName, controllerName, httpPath, httpMiddlewares, methods, needAcl, aclCode, hosts);
+      clazzName, protoName, controllerName, httpPath, httpMiddlewares, methods, needAcl, aclCode, hosts, timeout);
     ControllerMetadataUtil.setControllerMetadata(this.clazz, metadata);
     for (const method of metadata.methods) {
       const realPath = metadata.getMethodRealPath(method);

--- a/core/controller-decorator/src/impl/http/HTTPControllerMethodMetaBuilder.ts
+++ b/core/controller-decorator/src/impl/http/HTTPControllerMethodMetaBuilder.ts
@@ -106,12 +106,13 @@ export class HTTPControllerMethodMetaBuilder {
     const needAcl = MethodInfoUtil.hasMethodAcl(this.clazz, this.methodName);
     const aclCode = MethodInfoUtil.getMethodAcl(this.clazz, this.methodName);
     const hosts = MethodInfoUtil.getMethodHosts(this.clazz, this.methodName);
+    const timeout = MethodInfoUtil.getMethodTimeout(this.clazz, this.methodName);
     const realPath = parentPath
       ? path.posix.join(parentPath, httpPath)
       : httpPath;
     const paramTypeMap = this.buildParamType(realPath);
     const priority = this.getPriority();
     return new HTTPMethodMeta(
-      this.methodName, httpPath!, httpMethod!, middlewares, contextIndex, paramTypeMap, priority, needAcl, aclCode, hosts);
+      this.methodName, httpPath!, httpMethod!, middlewares, contextIndex, paramTypeMap, priority, needAcl, aclCode, hosts, timeout);
   }
 }

--- a/core/controller-decorator/src/model/HTTPControllerMeta.ts
+++ b/core/controller-decorator/src/model/HTTPControllerMeta.ts
@@ -14,6 +14,7 @@ export class HTTPControllerMeta implements ControllerMetadata {
   public readonly needAcl: boolean;
   public readonly aclCode?: string;
   public readonly hosts?: string[];
+  public readonly timeout?: number;
 
   constructor(
     className: string,
@@ -25,6 +26,7 @@ export class HTTPControllerMeta implements ControllerMetadata {
     needAcl: boolean,
     aclCode: string | undefined,
     hosts: string[] | undefined,
+    timeout: number | undefined,
   ) {
     this.protoName = protoName;
     this.controllerName = controllerName;
@@ -35,6 +37,7 @@ export class HTTPControllerMeta implements ControllerMetadata {
     this.needAcl = needAcl;
     this.aclCode = aclCode;
     this.hosts = hosts;
+    this.timeout = timeout;
   }
 
   getMethodRealPath(method: HTTPMethodMeta) {
@@ -74,5 +77,9 @@ export class HTTPControllerMeta implements ControllerMetadata {
       return method.aclCode;
     }
     return this.aclCode;
+  }
+
+  getMethodTimeout(method: HTTPMethodMeta): number | undefined {
+    return method.timeout || this.timeout;
   }
 }

--- a/core/controller-decorator/src/model/HTTPMethodMeta.ts
+++ b/core/controller-decorator/src/model/HTTPMethodMeta.ts
@@ -98,6 +98,7 @@ export class HTTPMethodMeta implements MethodMeta {
   public readonly needAcl: boolean;
   public readonly aclCode: string | undefined;
   public readonly hosts: string[] | undefined;
+  public readonly timeout: number | undefined;
 
   constructor(
     name: string,
@@ -110,6 +111,7 @@ export class HTTPMethodMeta implements MethodMeta {
     needAcl: boolean,
     aclCode: string | undefined,
     hosts: string[] | undefined,
+    timeout: number | undefined,
   ) {
     this.name = name;
     this.path = path;
@@ -121,6 +123,7 @@ export class HTTPMethodMeta implements MethodMeta {
     this.needAcl = needAcl;
     this.aclCode = aclCode;
     this.hosts = hosts;
+    this.timeout = timeout;
   }
 }
 

--- a/core/controller-decorator/src/util/ControllerInfoUtil.ts
+++ b/core/controller-decorator/src/util/ControllerInfoUtil.ts
@@ -1,9 +1,12 @@
 import {
-  CONTROLLER_ACL, CONTROLLER_AOP_MIDDLEWARES,
+  CONTROLLER_ACL,
+  CONTROLLER_AOP_MIDDLEWARES,
   CONTROLLER_HOST,
   CONTROLLER_MIDDLEWARES,
   CONTROLLER_NAME,
-  CONTROLLER_TYPE, IAdvice,
+  CONTROLLER_TIMEOUT_METADATA,
+  CONTROLLER_TYPE,
+  IAdvice,
 } from '@eggjs/tegg-types';
 import type { ControllerTypeLike, EggProtoImplClass, MiddlewareFunc } from '@eggjs/tegg-types';
 import { MetadataUtil } from '@eggjs/core-decorator';
@@ -61,5 +64,13 @@ export default class ControllerInfoUtil {
 
   static getControllerHosts(clazz: EggProtoImplClass): string[] | undefined {
     return MetadataUtil.getMetaData(CONTROLLER_HOST, clazz);
+  }
+
+  static setControllerTimeout(timeout: number, clazz: EggProtoImplClass) {
+    MetadataUtil.defineMetaData(CONTROLLER_TIMEOUT_METADATA, timeout, clazz);
+  }
+
+  static getControllerTimeout(clazz: EggProtoImplClass): number | undefined {
+    return MetadataUtil.getMetaData(CONTROLLER_TIMEOUT_METADATA, clazz);
   }
 }

--- a/core/controller-decorator/src/util/MethodInfoUtil.ts
+++ b/core/controller-decorator/src/util/MethodInfoUtil.ts
@@ -2,11 +2,14 @@ import { MetadataUtil } from '@eggjs/core-decorator';
 import { MapUtil } from '@eggjs/tegg-common-util';
 import {
   IAdvice,
-  METHOD_ACL, METHOD_AOP_MIDDLEWARES, METHOD_AOP_REGISTER_MAP,
+  METHOD_ACL,
+  METHOD_AOP_MIDDLEWARES,
+  METHOD_AOP_REGISTER_MAP,
   METHOD_CONTEXT_INDEX,
   METHOD_CONTROLLER_HOST,
   METHOD_CONTROLLER_TYPE_MAP,
   METHOD_MIDDLEWARES,
+  METHOD_TIMEOUT_METADATA,
 } from '@eggjs/tegg-types';
 import type { ControllerTypeLike, EggProtoImplClass, MiddlewareFunc } from '@eggjs/tegg-types';
 
@@ -16,6 +19,7 @@ type MethodContextIndexMap = Map<string, number>;
 type MethodMiddlewareMap = Map<string, MiddlewareFunc[]>;
 type MethodAopMiddlewareMap = Map<string, EggProtoImplClass<IAdvice>[]>;
 type MethodAclMap = Map<string, string | undefined>;
+type MethodTimeoutMap = Map<string, number>;
 
 export default class MethodInfoUtil {
   static setMethodControllerType(clazz: EggProtoImplClass, methodName: string, controllerType: ControllerTypeLike) {
@@ -98,5 +102,15 @@ export default class MethodInfoUtil {
   static registerAopMiddlewarePointcut(clazz: EggProtoImplClass, methodName: string) {
     const methodControllerMap: MethodAopRegisterMap = MetadataUtil.initOwnMapMetaData(METHOD_AOP_REGISTER_MAP, clazz, new Map());
     methodControllerMap.set(methodName, true);
+  }
+
+  static setMethodTimeout(timeout: number, clazz: EggProtoImplClass, methodName: string) {
+    const methodAclMap: MethodTimeoutMap = MetadataUtil.initOwnMapMetaData(METHOD_TIMEOUT_METADATA, clazz, new Map());
+    methodAclMap.set(methodName, timeout);
+  }
+
+  static getMethodTimeout(clazz: EggProtoImplClass, methodName: string): number | undefined {
+    const methodAclMap: MethodTimeoutMap | undefined = MetadataUtil.getMetaData(METHOD_TIMEOUT_METADATA, clazz);
+    return methodAclMap?.get(methodName);
   }
 }

--- a/core/controller-decorator/test/fixtures/HTTPFooController.ts
+++ b/core/controller-decorator/test/fixtures/HTTPFooController.ts
@@ -1,9 +1,9 @@
+import type { EggContext, IncomingHttpHeaders, Next } from '@eggjs/tegg-types';
 import { HTTPMethodEnum } from '@eggjs/tegg-types'
-import type { EggContext, Next, IncomingHttpHeaders } from '@eggjs/tegg-types';
 import { HTTPController } from '../../src/decorator/http/HTTPController';
 import { Context } from '../../src/decorator/Context';
 import { Middleware } from '../../src/decorator/Middleware';
-import { HTTPBody, HTTPParam, HTTPQueries, HTTPQuery, HTTPHeaders } from '../../src/decorator/http/HTTPParam';
+import { HTTPBody, HTTPHeaders, HTTPParam, HTTPQueries, HTTPQuery } from '../../src/decorator/http/HTTPParam';
 import { HTTPMethod } from '../../src/decorator/http/HTTPMethod';
 
 
@@ -128,4 +128,13 @@ export class Error2Controller {
   async bar(@Context() ctx: EggContext, id = 233, @HTTPParam() id2 = 233) {
     console.log(ctx, id, id2);
   }
+}
+
+@HTTPController({ timeout: 1000 })
+export class TimeoutController {
+  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/timeout-1' })
+  async timeout1() {}
+
+  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/timeout-2', timeout: 2000 })
+  async timeout2() {}
 }

--- a/core/controller-decorator/test/http/HTTPMeta.test.ts
+++ b/core/controller-decorator/test/http/HTTPMeta.test.ts
@@ -8,6 +8,7 @@ import {
   FooController,
   FoxController,
   FxxController,
+  TimeoutController,
 } from '../fixtures/HTTPFooController';
 import {
   BodyParamMeta,
@@ -179,5 +180,23 @@ describe('core/controller-decorator/test/http/HTTPMeta.test.ts', () => {
       { clazz: FooAdvice, order: 1000, adviceParams: undefined },
       { clazz: BarAdvice, order: 1000, adviceParams: undefined },
     ]);
+  });
+
+  describe('timeout', () => {
+    it('should work', () => {
+      const controllerMeta = ControllerMetaBuilderFactory.build(TimeoutController)! as HTTPControllerMeta;
+      const methodMeta1 = controllerMeta.methods.find(m => m.path === '/timeout-1')!;
+      const methodMeta2 = controllerMeta.methods.find(m => m.path === '/timeout-2')!;
+
+      assert.strictEqual(controllerMeta.getMethodTimeout(methodMeta1), 1000);
+      assert.strictEqual(controllerMeta.getMethodTimeout(methodMeta2), 2000);
+    });
+
+    it('should default be undefined', () => {
+      const controllerMeta = ControllerMetaBuilderFactory.build(FooController)! as HTTPControllerMeta;
+      const methodMeta = controllerMeta.methods[0];
+
+      assert.strictEqual(controllerMeta.getMethodTimeout(methodMeta), undefined);
+    });
   });
 });

--- a/core/core-decorator/src/util/QualifierUtil.ts
+++ b/core/core-decorator/src/util/QualifierUtil.ts
@@ -4,10 +4,7 @@ import type { EggProtoImplClass, QualifierAttribute, QualifierInfo, QualifierVal
 import { MetadataUtil } from './MetadataUtil';
 
 export class QualifierUtil {
-  static addProtoQualifier(clazz: EggProtoImplClass, attribute: QualifierAttribute, value: QualifierValue, isForceReplacement?: boolean) {
-    if (QualifierUtil.getQualifierValue(clazz, attribute) && !isForceReplacement) {
-      throw new Error(`Qualifier Error: clazz ${clazz.name} attribute ${attribute.toString()} has been implemented`);
-    }
+  static addProtoQualifier(clazz: EggProtoImplClass, attribute: QualifierAttribute, value: QualifierValue) {
     const qualifiers = MetadataUtil.initOwnMapMetaData(QUALIFIER_META_DATA, clazz, new Map<QualifierAttribute, QualifierValue>());
     qualifiers.set(attribute, value);
   }

--- a/core/dynamic-inject/src/QualifierImplDecoratorUtil.ts
+++ b/core/dynamic-inject/src/QualifierImplDecoratorUtil.ts
@@ -4,10 +4,10 @@ import { QualifierImplUtil } from './QualifierImplUtil';
 
 export class QualifierImplDecoratorUtil {
   static generatorDecorator<T extends object, Enum extends ImplTypeEnum>(abstractClazz: EggAbstractClazz<T>, attribute: QualifierAttribute): ImplDecorator<T, Enum> {
-    return function(type: Enum[keyof Enum], isForceReplacement?: boolean) {
+    return function(type: Enum[keyof Enum]) {
       return function(clazz: EggProtoImplClass<T>) {
-        QualifierImplUtil.addQualifierImpl(abstractClazz, type, clazz, isForceReplacement);
-        QualifierUtil.addProtoQualifier(clazz, attribute, type, isForceReplacement);
+        QualifierImplUtil.addQualifierImpl(abstractClazz, type, clazz);
+        QualifierUtil.addProtoQualifier(clazz, attribute, type);
       };
     };
   }

--- a/core/dynamic-inject/src/QualifierImplUtil.ts
+++ b/core/dynamic-inject/src/QualifierImplUtil.ts
@@ -3,10 +3,7 @@ import { QUALIFIER_IMPL_MAP } from '@eggjs/tegg-types';
 import type { EggAbstractClazz, EggProtoImplClass, QualifierValue } from '@eggjs/tegg-types';
 
 export class QualifierImplUtil {
-  static addQualifierImpl(abstractClazz: EggAbstractClazz, qualifierValue: QualifierValue, implClazz: EggProtoImplClass, isForceReplacement?: boolean) {
-    if (QualifierImplUtil.getQualifierImp(abstractClazz, qualifierValue) && !isForceReplacement) {
-      throw new Error(`Qualifier Error: abstractClazz ${abstractClazz.name} qualifierValue ${qualifierValue.toString()} has been implemented`);
-    }
+  static addQualifierImpl(abstractClazz: EggAbstractClazz, qualifierValue: QualifierValue, implClazz: EggProtoImplClass) {
     const implMap = MetadataUtil.initOwnMapMetaData(QUALIFIER_IMPL_MAP, abstractClazz as unknown as EggProtoImplClass, new Map());
     implMap.set(qualifierValue, implClazz);
   }

--- a/core/types/controller-decorator/HTTPController.ts
+++ b/core/types/controller-decorator/HTTPController.ts
@@ -2,4 +2,5 @@ export interface HTTPControllerParams {
   protoName?: string;
   controllerName?: string;
   path?: string;
+  timeout?: number;
 }

--- a/core/types/controller-decorator/HTTPMethod.ts
+++ b/core/types/controller-decorator/HTTPMethod.ts
@@ -4,4 +4,5 @@ export interface HTTPMethodParams {
   method: HTTPMethodEnum;
   path: string;
   priority?: number;
+  timeout?: number;
 }

--- a/core/types/controller-decorator/MetadataKey.ts
+++ b/core/types/controller-decorator/MetadataKey.ts
@@ -4,6 +4,7 @@ export const CONTROLLER_HOST = Symbol.for('EggPrototype#controllerHost');
 export const CONTROLLER_MIDDLEWARES = Symbol.for('EggPrototype#controller#middlewares');
 export const CONTROLLER_AOP_MIDDLEWARES = Symbol.for('EggPrototype#controller#aopMiddlewares');
 export const CONTROLLER_ACL = Symbol.for('EggPrototype#controller#acl');
+export const CONTROLLER_TIMEOUT_METADATA = Symbol.for('EggPrototype#controller#timeout');
 
 export const CONTROLLER_META_DATA = Symbol.for('EggPrototype#controller#metaData');
 
@@ -21,3 +22,4 @@ export const METHOD_MIDDLEWARES = Symbol.for('EggPrototype#method#middlewares');
 export const METHOD_AOP_MIDDLEWARES = Symbol.for('EggPrototype#method#aopMiddlewares');
 export const METHOD_AOP_REGISTER_MAP = Symbol.for('EggPrototype#method#aopMiddlewaresRegister');
 export const METHOD_ACL = Symbol.for('EggPrototype#method#acl');
+export const METHOD_TIMEOUT_METADATA = Symbol.for('EggPrototype#method#timeout');

--- a/core/types/dynamic-inject.ts
+++ b/core/types/dynamic-inject.ts
@@ -5,7 +5,7 @@ export type ImplTypeEnum = {
   [id: string]: QualifierValue;
 };
 
-export type ImplDecorator<T extends object, Enum extends ImplTypeEnum> = (type: Enum[keyof Enum], isForceReplacement?: boolean) => ((clazz: EggProtoImplClass<T>) => void);
+export type ImplDecorator<T extends object, Enum extends ImplTypeEnum> = (type: Enum[keyof Enum]) => ((clazz: EggProtoImplClass<T>) => void);
 
 export interface EggObjectFactory {
   getEggObject<T extends object>(abstractClazz: EggAbstractClazz<T>, qualifierValue: QualifierValue): Promise<T>;

--- a/plugin/controller/lib/impl/http/HTTPMethodRegister.ts
+++ b/plugin/controller/lib/impl/http/HTTPMethodRegister.ts
@@ -1,5 +1,8 @@
 import assert from 'assert';
+import pathToRegexp from 'path-to-regexp';
+import { EggRouter } from '@eggjs/router';
 import { Context, Router } from 'egg';
+import { FrameworkErrorFormater } from 'egg-errors';
 import {
   EggContext,
   HTTPControllerMeta,
@@ -11,15 +14,13 @@ import {
   QueryParamMeta,
   HTTPCookies,
 } from '@eggjs/tegg';
+import { TimerUtil } from '@eggjs/tegg-common-util';
 import { EggContainerFactory } from '@eggjs/tegg-runtime';
 import { EggPrototype } from '@eggjs/tegg-metadata';
 import { RootProtoManager } from '../../RootProtoManager';
-import pathToRegexp from 'path-to-regexp';
 import { aclMiddlewareFactory } from './Acl';
 import { HTTPRequest } from './Req';
 import { RouterConflictError } from '../../errors';
-import { FrameworkErrorFormater } from 'egg-errors';
-import { EggRouter } from '@eggjs/router';
 
 const noop = () => {
   // ...
@@ -54,6 +55,7 @@ export class HTTPMethodRegister {
     const hasContext = methodMeta.contextParamIndex !== undefined;
     const contextIndex = methodMeta.contextParamIndex;
     const methodArgsLength = argsLength + (hasContext ? 1 : 0);
+    const timeout = this.controllerMeta.getMethodTimeout(methodMeta);
     const self = this;
     return async function(ctx: Context, next: Next) {
       // if hosts is not empty and host is not matched, not execute
@@ -106,7 +108,19 @@ export class HTTPMethodRegister {
             assert.fail('never arrive');
         }
       }
-      const body = await Reflect.apply(realMethod, realObj, args);
+
+      let body: any;
+      if (!timeout) {
+        body = await Reflect.apply(realMethod, realObj, args);
+      } else {
+        body = await Promise.race([
+          Reflect.apply(realMethod, realObj, args),
+          TimerUtil.sleep(timeout).then(() => {
+            ctx.logger.error(`timeout after ${timeout}ms`);
+            ctx.throw(500, 'timeout');
+          }),
+        ]);
+      }
       // https://github.com/koajs/koa/blob/master/lib/response.js#L88
       // ctx.status is set
       const explicitStatus = (ctx.response as any)._explicitStatus;

--- a/plugin/controller/test/fixtures/apps/controller-app/app/controller/TimeoutController.ts
+++ b/plugin/controller/test/fixtures/apps/controller-app/app/controller/TimeoutController.ts
@@ -1,0 +1,25 @@
+import { HTTPController, HTTPMethod, HTTPMethodEnum } from '@eggjs/tegg';
+import { TimerUtil } from '@eggjs/tegg-common-util';
+
+@HTTPController({
+  timeout: 1000,
+})
+export class TimeoutController {
+  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/timeout-1', timeout: 500 })
+  async timeout1() {
+    await TimerUtil.sleep(600);
+    return 'success';
+  }
+
+  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/timeout-2', timeout: 500 })
+  async timeout2() {
+    await TimerUtil.sleep(300);
+    return 'success';
+  }
+
+  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/timeout-3' })
+  async timeout3() {
+    await TimerUtil.sleep(1200);
+    return 'success';
+  }
+}

--- a/plugin/controller/test/fixtures/apps/http-inject-app/app/controller/AppController.ts
+++ b/plugin/controller/test/fixtures/apps/http-inject-app/app/controller/AppController.ts
@@ -10,7 +10,9 @@ import {
   HTTPRequest,
   Cookies,
   HTTPCookies,
-  Inject, BackgroundTaskHelper } from '@eggjs/tegg';
+  Inject,
+  BackgroundTaskHelper,
+} from '@eggjs/tegg';
 import { countMw } from '../middleware/count_mw';
 import { Tracer } from '@eggjs/module-test-util';
 import { Readable } from 'node:stream';
@@ -30,8 +32,6 @@ export class AppController {
     method: HTTPMethodEnum.POST,
     path: '/testRequest',
   })
-
-
   async testRequest(@Context() ctx: EggContext, @Request() request: HTTPRequest, @Cookies() cookies: HTTPCookies) {
     const traceId = await ctx.tracer.traceId;
     return {
@@ -43,7 +43,6 @@ export class AppController {
       cookies: cookies.get('test', { signed: false }),
     };
   }
-
 
   @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/stream' })
   async streamResponse(@Context() ctx: EggContext) {
@@ -68,6 +67,7 @@ export class AppController {
   @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/error_stream' })
   async errorStreamResponse(@Context() ctx: EggContext) {
     const self = this;
+
     async function* generate(count = 5, duration = 500) {
       yield '<html><head><title>hello stream</title></head><body>';
       for (let i = 0; i < count; i++) {
@@ -86,5 +86,15 @@ export class AppController {
     ctx.type = 'html';
     ctx.set('X-Accel-Buffering', 'no');
     return Readable.from(generate());
+  }
+
+  @HTTPMethod({
+    method: HTTPMethodEnum.GET,
+    path: '/test-timeout',
+    timeout: 100,
+  })
+  async testTimeout() {
+    await setTimeout(200);
+    return 'success';
   }
 }

--- a/plugin/controller/test/http/decorator.test.ts
+++ b/plugin/controller/test/http/decorator.test.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+import mm from 'egg-mock';
+
+describe('plugin/controller/test/http/decorator.test.ts', () => {
+  let app;
+
+  beforeEach(() => {
+    mm(process.env, 'EGG_TYPESCRIPT', true);
+  });
+
+  afterEach(() => {
+    mm.restore();
+  });
+
+  before(async () => {
+    mm(process.env, 'EGG_TYPESCRIPT', true);
+    mm(process, 'cwd', () => {
+      return path.join(__dirname, '../..');
+    });
+    app = mm.app({
+      baseDir: path.join(__dirname, '../fixtures/apps/controller-app'),
+      framework: require.resolve('egg'),
+    });
+    await app.ready();
+  });
+
+  after(() => {
+    return app.close();
+  });
+
+  it('should timeout for method timeout', async () => {
+    await app.httpRequest()
+      .get('/timeout-1')
+      .expect(500);
+  });
+
+  it('should not timeout', async () => {
+    await app.httpRequest()
+      .get('/timeout-2')
+      .expect(200, 'success');
+  });
+
+  it('should timeout for controller timeout', async () => {
+    await app.httpRequest()
+      .get('/timeout-3')
+      .expect(500);
+  });
+});

--- a/plugin/controller/test/lib/EggControllerLoader.test.ts
+++ b/plugin/controller/test/lib/EggControllerLoader.test.ts
@@ -17,7 +17,7 @@ describe('plugin/controller/test/lib/EggModuleLoader.test.ts', () => {
     const controllerDir = path.join(__dirname, '../fixtures/apps/controller-app/app/controller');
     const loader = new EggControllerLoader(controllerDir);
     const clazzs = loader.load();
-    assert(clazzs.length === 7);
+    assert.strictEqual(clazzs.length, 8);
     const AppController = clazzs[0];
     const metadata = ControllerMetadataUtil.getControllerMetadata(AppController);
     assert(metadata);

--- a/plugin/tegg/lib/AppLoadUnit.ts
+++ b/plugin/tegg/lib/AppLoadUnit.ts
@@ -49,7 +49,7 @@ export class AppLoadUnit implements LoadUnit {
         value: this.name,
       }];
       defaultQualifier.forEach(qualifier => {
-        QualifierUtil.addProtoQualifier(clazz, qualifier.attribute, qualifier.value, true);
+        QualifierUtil.addProtoQualifier(clazz, qualifier.attribute, qualifier.value);
       });
       const protos = await EggPrototypeCreatorFactory.createProto(clazz, this);
       for (const proto of protos) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying timeout values at both the controller and method levels in HTTP controllers and methods, enforceable during method execution.
  - Introduced timeout handling in HTTP request processing, returning errors when execution exceeds configured limits.
  - Added example controllers and endpoints demonstrating timeout behavior.

- **Refactor**
  - Simplified qualifier implementation and decorator utilities by removing the force replacement parameter, allowing unconditional overwriting.

- **Tests**
  - Added comprehensive tests verifying timeout behavior and inheritance in HTTP controllers and methods.

- **Documentation**
  - Updated documentation to reflect removal of force replacement logic in qualifier decorators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->