### PR TITLE
feat: add mcp stateless

### DIFF
--- a/plugin/controller/README.md
+++ b/plugin/controller/README.md
@@ -313,3 +313,24 @@ export class McpController {
 
 #### MCP 地址
 MCP controller 完整的实现了 SSE / streamable HTTP / streamable stateless HTTP 三种模式，默认情况下，他们的路径分别是 `/mcp/init` `/mcp/stream` `/mcp/stateless/stream`, 你可以根据你所需要的场景，灵活使用对应的接口。 
+
+``` ts
+// config.{env}.ts
+import { randomUUID } from 'node:crypto';
+
+export default () => {
+
+  const config = {
+    mcp: {
+      sseInitPath: '/mcp/init', // SSE path
+      sseMessagePath: '/mcp/message', // SSE message path
+      streamPath: '/mcp/stream', // streamable path
+      statelessStreamPath: '/mcp/stateless/stream', // stateless streamable path
+      sessionIdGenerator: randomUUID, 
+    },
+  };
+
+  return config;
+};
+
+```

--- a/plugin/controller/app.ts
+++ b/plugin/controller/app.ts
@@ -108,6 +108,9 @@ export default class ControllerAppBootHook {
     // The HTTPControllerRegister will collect all the methods
     // and register methods after collect is done.
     HTTPControllerRegister.instance?.doRegister(this.app.rootProtoManager);
+    if (this.app.mcpProxy) {
+      MCPControllerRegister.connectStatelessStreamTransport();
+    }
   }
 
   async beforeClose() {

--- a/plugin/controller/app.ts
+++ b/plugin/controller/app.ts
@@ -73,6 +73,7 @@ export default class ControllerAppBootHook {
             this.app.config.mcp.sseInitPath,
             this.app.config.mcp.sseMessagePath,
             this.app.config.mcp.streamPath,
+            this.app.config.mcp.statelessStreamPath,
             ...(Array.isArray(this.app.config.security.csrf.ignore)
               ? this.app.config.security.csrf.ignore
               : [ this.app.config.security.csrf.ignore ]),
@@ -83,6 +84,7 @@ export default class ControllerAppBootHook {
           this.app.config.mcp.sseInitPath,
           this.app.config.mcp.sseMessagePath,
           this.app.config.mcp.streamPath,
+          this.app.config.mcp.statelessStreamPath,
         ];
       }
     }

--- a/plugin/controller/app/middleware/mcp_body_middleware.ts
+++ b/plugin/controller/app/middleware/mcp_body_middleware.ts
@@ -3,7 +3,7 @@ import pathToRegexp from 'path-to-regexp';
 
 export default () => {
   return async function mcpBodyMiddleware(ctx: EggContext, next: Next) {
-    const arr = [ ctx.app.config.mcp.sseInitPath, ctx.app.config.mcp.sseMessagePath, ctx.app.config.mcp.streamPath ];
+    const arr = [ ctx.app.config.mcp.sseInitPath, ctx.app.config.mcp.sseMessagePath, ctx.app.config.mcp.streamPath, ctx.app.config.mcp.statelessStreamPath ];
     const res = arr.some(igPath => {
       const match = pathToRegexp(igPath, [], {
         end: false,

--- a/plugin/controller/config/config.default.ts
+++ b/plugin/controller/config/config.default.ts
@@ -7,6 +7,7 @@ export default () => {
       sseInitPath: '/mcp/init',
       sseMessagePath: '/mcp/message',
       streamPath: '/mcp/stream',
+      statelessStreamPath: '/mcp/stateless/stream',
       sessionIdGenerator: randomUUID,
     },
   };

--- a/plugin/controller/lib/impl/mcp/MCPConfig.ts
+++ b/plugin/controller/lib/impl/mcp/MCPConfig.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from 'node:crypto';
+import { EventStore } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { InMemoryEventStore } from '@modelcontextprotocol/sdk/examples/shared/inMemoryEventStore.js';
+
+export interface MCPConfigOptions {
+  sseInitPath: string;
+  sseMessagePath: string;
+  streamPath: string;
+  statelessStreamPath: string;
+  sessionIdGenerator?: () => string;
+  eventStore?: EventStore;
+  sseHeartTime?: number;
+}
+
+export class MCPConfig {
+  private _sseInitPath: string;
+  private _sseMessagePath: string;
+  private _streamPath: string;
+  private _statelessStreamPath: string;
+  private _sessionIdGenerator: () => string;
+  private _eventStore: EventStore;
+  private _sseHeartTime: number;
+
+  constructor(options: MCPConfigOptions) {
+    this._sessionIdGenerator = options.sessionIdGenerator ?? randomUUID;
+    this._sseInitPath = options.sseInitPath;
+    this._sseMessagePath = options.sseMessagePath;
+    this._streamPath = options.streamPath;
+    this._statelessStreamPath = options.statelessStreamPath;
+    this._eventStore = options.eventStore ?? new InMemoryEventStore();
+    this._sseHeartTime = options.sseHeartTime ?? 25000;
+  }
+
+  get sseInitPath() {
+    return this._sseInitPath;
+  }
+
+  get sseMessagePath() {
+    return this._sseMessagePath;
+  }
+
+  get streamPath() {
+    return this._streamPath;
+  }
+
+  get statelessStreamPath() {
+    return this._statelessStreamPath;
+  }
+
+  get sessionIdGenerator() {
+    return this._sessionIdGenerator;
+  }
+
+  get eventStore() {
+    return this._eventStore;
+  }
+
+  get sseHeartTime() {
+    return this._sseHeartTime;
+  }
+}

--- a/plugin/controller/lib/impl/mcp/MCPControllerRegister.ts
+++ b/plugin/controller/lib/impl/mcp/MCPControllerRegister.ts
@@ -91,7 +91,7 @@ export class MCPControllerRegister implements ControllerRegister {
       const req = new IncomingMessage(socket);
       const res = new ServerResponse(req);
       req.method = 'POST';
-      req.url = '/mcp/stream';
+      req.url = MCPControllerRegister.instance.mcpConfig.statelessStreamPath;
       req.headers = {
         accept: 'application/json, text/event-stream',
         'content-type': 'application/json',

--- a/plugin/controller/package.json
+++ b/plugin/controller/package.json
@@ -19,6 +19,8 @@
   "files": [
     "app.js",
     "app.d.ts",
+    "config/**/*.js",
+    "config/**/*.d.ts",
     "lib/**/*.js",
     "lib/**/*.d.ts",
     "app/**/*.js",

--- a/plugin/mcp-proxy/app.ts
+++ b/plugin/mcp-proxy/app.ts
@@ -1,10 +1,16 @@
 import { Application } from 'egg';
+import { MCPProxyHook } from './index';
+import { MCPControllerRegister } from '@eggjs/tegg-controller-plugin/lib/impl/mcp/MCPControllerRegister';
 
 export default class AppHook {
   private readonly agent: Application;
 
   constructor(agent: Application) {
     this.agent = agent;
+  }
+
+  configWillLoad() {
+    MCPControllerRegister.addHook(MCPProxyHook);
   }
 
   async didLoad() {

--- a/plugin/mcp-proxy/app/extend/agent.ts
+++ b/plugin/mcp-proxy/app/extend/agent.ts
@@ -10,6 +10,7 @@ export default {
         logger: (this as unknown as Application).logger,
         messenger: (this as unknown as Application).messenger,
         app: this as unknown as Application,
+        isAgent: true,
       });
     }
     return this[MCP_PROXY];

--- a/plugin/mcp-proxy/package.json
+++ b/plugin/mcp-proxy/package.json
@@ -16,8 +16,17 @@
   "files": [
     "app.js",
     "app.d.ts",
+    "agent.js",
+    "agent.d.ts",
+    "index.js",
+    "index.d.ts",
+    "config/**/*.js",
+    "config/**/*.d.ts",
     "lib/**/*.js",
-    "lib/**/*.d.ts"
+    "lib/**/*.d.ts",
+    "app/**/*.js",
+    "app/**/*.d.ts",
+    "typings/*.d.ts"
   ],
   "scripts": {
     "test": "cross-env NODE_ENV=test NODE_OPTIONS='--no-deprecation' mocha",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced stateless stream transport support for MCP controllers, accessible via a new endpoint for streamable HTTP interactions.
  - Added centralized configuration for MCP controller endpoints and stream transport options.
- **Documentation**
  - Expanded documentation to include detailed guidance and examples on MCP annotations, controller setup, and usage of new stream endpoints.
- **Bug Fixes**
  - Middleware updated to properly handle request body parsing for the new stateless stream endpoint.
- **Tests**
  - Added comprehensive tests to verify stateless streamable MCP controller functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->