### PR TITLE
feat: add mcp global middleware

### DIFF
--- a/plugin/controller/lib/impl/mcp/MCPServerHelper.ts
+++ b/plugin/controller/lib/impl/mcp/MCPServerHelper.ts
@@ -50,8 +50,10 @@ export class MCPServerHelper {
       ) as ReturnType<ReadResourceCallback>;
     };
     const name = resourceMeta.mcpName ?? resourceMeta.name;
-    if (resourceMeta.uri || resourceMeta.template) {
-      this.server.registerResource(name, resourceMeta.uri ?? resourceMeta.template!, resourceMeta.metadata ?? {}, handler);
+    if (resourceMeta.uri) {
+      this.server.registerResource(name, resourceMeta.uri, resourceMeta.metadata ?? {}, handler);
+    } else if (resourceMeta.template) {
+      this.server.registerResource(name, resourceMeta.template, resourceMeta.metadata ?? {}, handler);
     } else {
       throw new Error(`MCPResource ${name} must have uri or template`);
     }

--- a/plugin/controller/test/fixtures/apps/mcp-app/app/controller/McpController.ts
+++ b/plugin/controller/test/fixtures/apps/mcp-app/app/controller/McpController.ts
@@ -13,6 +13,8 @@ import {
   Inject,
   ContextProto,
   ToolArgsSchema,
+  Extra,
+  ToolExtra,
 } from '@eggjs/tegg';
 import z from 'zod';
 
@@ -85,6 +87,18 @@ export class McpController {
         {
           type: 'text',
           text: `hello ${this.user}`,
+        },
+      ],
+    };
+  }
+
+  @MCPTool()
+  async traceTest(@Extra() extra: ToolExtra): Promise<MCPToolResponse> {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `hello ${extra.requestInfo?.headers.trace}`,
         },
       ],
     };

--- a/plugin/controller/test/fixtures/apps/mcp-app/app/middleware/tracelog.js
+++ b/plugin/controller/test/fixtures/apps/mcp-app/app/middleware/tracelog.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = () => {
+  return async function tracelog(ctx, next) {
+    ctx.req.headers.trace = 'middleware';
+    await next();
+  };
+};

--- a/plugin/controller/test/fixtures/apps/mcp-app/config/config.default.js
+++ b/plugin/controller/test/fixtures/apps/mcp-app/config/config.default.js
@@ -14,6 +14,9 @@ module.exports = function() {
       sessionIdGenerator: ctx => {
         return ctx.request.headers['custom-session-id'] || randomUUID();
       },
+      middleware: [
+        'tracelog',
+      ],
     },
   };
   return config;

--- a/plugin/controller/test/mcp/mcp.test.ts
+++ b/plugin/controller/test/mcp/mcp.test.ts
@@ -133,6 +133,10 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
           description: undefined,
           name: 'echoUser',
         },
+        {
+          description: undefined,
+          name: 'traceTest',
+        },
       ]);
 
       const toolRes = await sseClient.callTool({
@@ -151,6 +155,14 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       });
       assert.deepEqual(userRes, {
         content: [{ type: 'text', text: 'hello akita' }],
+      });
+
+      const traceRes = await sseClient.callTool({
+        name: 'traceTest',
+        arguments: {},
+      });
+      assert.deepEqual(traceRes, {
+        content: [{ type: 'text', text: 'hello middleware' }],
       });
       // notification
       const notificationResp = await startNotificationTool(sseClient);
@@ -260,6 +272,10 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
           description: undefined,
           name: 'echoUser',
         },
+        {
+          description: undefined,
+          name: 'traceTest',
+        },
       ]);
 
       const toolRes = await streamableClient.callTool({
@@ -278,6 +294,14 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       });
       assert.deepEqual(userRes, {
         content: [{ type: 'text', text: 'hello akita' }],
+      });
+
+      const traceRes = await streamableClient.callTool({
+        name: 'traceTest',
+        arguments: {},
+      });
+      assert.deepEqual(traceRes, {
+        content: [{ type: 'text', text: 'hello middleware' }],
       });
       // notification
       const notificationResp = await startNotificationTool(streamableClient);
@@ -391,6 +415,10 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
           description: undefined,
           name: 'echoUser',
         },
+        {
+          description: undefined,
+          name: 'traceTest',
+        },
       ]);
 
       const toolRes = await streamableClient.callTool({
@@ -409,6 +437,14 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       });
       assert.deepEqual(userRes, {
         content: [{ type: 'text', text: 'hello akita' }],
+      });
+
+      const traceRes = await streamableClient.callTool({
+        name: 'traceTest',
+        arguments: {},
+      });
+      assert.deepEqual(traceRes, {
+        content: [{ type: 'text', text: 'hello middleware' }],
       });
       // notification
       const notificationResp = await startNotificationTool(streamableClient);

--- a/plugin/controller/test/mcp/mcpCluster.test.ts
+++ b/plugin/controller/test/mcp/mcpCluster.test.ts
@@ -143,6 +143,10 @@ describe('plugin/controller/test/mcp/mcpCluster.test.ts', () => {
           description: undefined,
           name: 'echoUser',
         },
+        {
+          description: undefined,
+          name: 'traceTest',
+        },
       ]);
 
       const toolRes = await sseClient.callTool({
@@ -160,6 +164,14 @@ describe('plugin/controller/test/mcp/mcpCluster.test.ts', () => {
       });
       assert.deepEqual(userRes, {
         content: [{ type: 'text', text: 'hello akita' }],
+      });
+
+      const traceRes = await sseClient.callTool({
+        name: 'traceTest',
+        arguments: {},
+      });
+      assert.deepEqual(traceRes, {
+        content: [{ type: 'text', text: 'hello middleware' }],
       });
       // notification
       const notificationResp = await startNotificationTool(sseClient);
@@ -269,6 +281,10 @@ describe('plugin/controller/test/mcp/mcpCluster.test.ts', () => {
           description: undefined,
           name: 'echoUser',
         },
+        {
+          description: undefined,
+          name: 'traceTest',
+        },
       ]);
 
       const toolRes = await streamableClient.callTool({
@@ -286,6 +302,14 @@ describe('plugin/controller/test/mcp/mcpCluster.test.ts', () => {
       });
       assert.deepEqual(userRes, {
         content: [{ type: 'text', text: 'hello akita' }],
+      });
+
+      const traceRes = await streamableClient.callTool({
+        name: 'traceTest',
+        arguments: {},
+      });
+      assert.deepEqual(traceRes, {
+        content: [{ type: 'text', text: 'hello middleware' }],
       });
       // notification
       const notificationResp = await startNotificationTool(streamableClient);
@@ -399,6 +423,10 @@ describe('plugin/controller/test/mcp/mcpCluster.test.ts', () => {
           description: undefined,
           name: 'echoUser',
         },
+        {
+          description: undefined,
+          name: 'traceTest',
+        },
       ]);
 
       const toolRes = await streamableClient.callTool({
@@ -416,6 +444,14 @@ describe('plugin/controller/test/mcp/mcpCluster.test.ts', () => {
       });
       assert.deepEqual(userRes, {
         content: [{ type: 'text', text: 'hello akita' }],
+      });
+
+      const traceRes = await streamableClient.callTool({
+        name: 'traceTest',
+        arguments: {},
+      });
+      assert.deepEqual(traceRes, {
+        content: [{ type: 'text', text: 'hello middleware' }],
       });
       // notification
       const notificationResp = await startNotificationTool(streamableClient);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying global middleware to MCP server handlers, configurable via the application settings.
  * Introduced a sample middleware that sets a custom header for requests.
  * Added a new "traceTest" tool endpoint that demonstrates middleware effects by returning a response reflecting the middleware-modified header.

* **Tests**
  * Enhanced integration and cluster tests to verify the presence and correct behavior of the new "traceTest" tool and middleware functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->