### PR TITLE
fix: concurrent init

### DIFF
--- a/core/runtime/src/impl/ContextInitiator.ts
+++ b/core/runtime/src/impl/ContextInitiator.ts
@@ -8,20 +8,25 @@ const CONTEXT_INITIATOR = Symbol('EggContext#ContextInitiator');
 export class ContextInitiator {
   private readonly eggContext: EggRuntimeContext;
   private readonly eggObjectInitRecorder: WeakMap<EggObject, boolean>;
+  private readonly eggObjectInitPromise: WeakMap<EggObject, Promise<void[]>>;
 
   constructor(eggContext: EggRuntimeContext) {
     this.eggContext = eggContext;
     this.eggObjectInitRecorder = new WeakMap();
+    this.eggObjectInitPromise = new WeakMap();
     this.eggContext.set(CONTEXT_INITIATOR, this);
   }
 
   async init(obj: EggObject) {
     if (this.eggObjectInitRecorder.get(obj) === true) {
+      if (this.eggObjectInitPromise.has(obj)) {
+        await this.eggObjectInitPromise.get(obj);
+      }
       return;
     }
     this.eggObjectInitRecorder.set(obj, true);
     const injectObjectProtos = ContextObjectGraph.getContextProto(obj.proto);
-    await Promise.all(injectObjectProtos.map(async injectObject => {
+    const initPromise = Promise.all(injectObjectProtos.map(async injectObject => {
       const proto = injectObject.proto;
       const loadUnit = LoadUnitFactory.getLoadUnitById(proto.loadUnitId);
       if (!loadUnit) {
@@ -29,6 +34,10 @@ export class ContextInitiator {
       }
       await EggContainerFactory.getOrCreateEggObject(proto, injectObject.objName);
     }));
+
+    this.eggObjectInitPromise.set(obj, initPromise);
+    await initPromise;
+    this.eggObjectInitPromise.delete(obj);
   }
 
   static createContextInitiator(context: EggRuntimeContext): ContextInitiator {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent initialization to ensure multiple simultaneous calls to initialize the same object will properly await the same process, preventing duplicate work and ensuring consistency.

* **Tests**
  * Added a new test suite to verify correct behavior during concurrent initialization, ensuring that multiple simultaneous initializations resolve as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->