### PR TITLE
fix: csrf type is bool bug

### DIFF
--- a/plugin/controller/app.ts
+++ b/plugin/controller/app.ts
@@ -68,25 +68,27 @@ export default class ControllerAppBootHook {
       // Don't let the mcp's body be consumed
       this.app.config.coreMiddleware.unshift('mcpBodyMiddleware');
 
-      if (this.app.config.security.csrf.ignore) {
-        if (Array.isArray(this.app.config.security.csrf.ignore)) {
+      if (this.app.config.security.csrf || this.app.config.security.csrf.enable) {
+        if (this.app.config.security.csrf.ignore) {
+          if (Array.isArray(this.app.config.security.csrf.ignore)) {
+            this.app.config.security.csrf.ignore = [
+              this.app.config.mcp.sseInitPath,
+              this.app.config.mcp.sseMessagePath,
+              this.app.config.mcp.streamPath,
+              this.app.config.mcp.statelessStreamPath,
+              ...(Array.isArray(this.app.config.security.csrf.ignore)
+                ? this.app.config.security.csrf.ignore
+                : [ this.app.config.security.csrf.ignore ]),
+            ];
+          }
+        } else {
           this.app.config.security.csrf.ignore = [
             this.app.config.mcp.sseInitPath,
             this.app.config.mcp.sseMessagePath,
             this.app.config.mcp.streamPath,
             this.app.config.mcp.statelessStreamPath,
-            ...(Array.isArray(this.app.config.security.csrf.ignore)
-              ? this.app.config.security.csrf.ignore
-              : [ this.app.config.security.csrf.ignore ]),
           ];
         }
-      } else {
-        this.app.config.security.csrf.ignore = [
-          this.app.config.mcp.sseInitPath,
-          this.app.config.mcp.sseMessagePath,
-          this.app.config.mcp.streamPath,
-          this.app.config.mcp.statelessStreamPath,
-        ];
       }
     }
   }
@@ -114,7 +116,7 @@ export default class ControllerAppBootHook {
   }
 
   async willReady() {
-    if (majorVersion >= 18) {
+    if (majorVersion >= 18 && (this.app.config.security.csrf || this.app.config.security.csrf.enable)) {
       await MCPControllerRegister.connectStatelessStreamTransport();
       const names = MCPControllerRegister.instance?.mcpConfig.getMultipleServerNames();
       if (names && names.length > 0) {

--- a/plugin/controller/app.ts
+++ b/plugin/controller/app.ts
@@ -12,6 +12,7 @@ import { EggControllerPrototypeHook } from './lib/EggControllerPrototypeHook';
 import { RootProtoManager } from './lib/RootProtoManager';
 import { EggControllerLoader } from './lib/EggControllerLoader';
 import { MCPControllerRegister } from './lib/impl/mcp/MCPControllerRegister';
+import assert from 'node:assert';
 
 // Load Controller process
 // 1. await add load unit is ready, controller may depend other load unit
@@ -61,6 +62,16 @@ export default class ControllerAppBootHook {
       },
     );
 
+    if (this.app.config.security?.csrf !== void 0) {
+      assert(typeof this.app.config.security.csrf === 'boolean' || typeof this.app.config.security.csrf === 'object', 'csrf must be boolean or object');
+
+      if (typeof this.app.config.security.csrf === 'boolean') {
+        this.app.config.security.csrf = {
+          enable: this.app.config.security.csrf,
+        };
+      }
+    }
+
     // init http root proto middleware
     this.prepareMiddleware(this.app.config.coreMiddleware);
     if (majorVersion >= 18) {
@@ -68,26 +79,34 @@ export default class ControllerAppBootHook {
       // Don't let the mcp's body be consumed
       this.app.config.coreMiddleware.unshift('mcpBodyMiddleware');
 
-      if (this.app.config.security.csrf || this.app.config.security.csrf.enable) {
-        if (this.app.config.security.csrf.ignore) {
-          if (Array.isArray(this.app.config.security.csrf.ignore)) {
-            this.app.config.security.csrf.ignore = [
-              this.app.config.mcp.sseInitPath,
-              this.app.config.mcp.sseMessagePath,
-              this.app.config.mcp.streamPath,
-              this.app.config.mcp.statelessStreamPath,
-              ...(Array.isArray(this.app.config.security.csrf.ignore)
-                ? this.app.config.security.csrf.ignore
-                : [ this.app.config.security.csrf.ignore ]),
-            ];
-          }
-        } else {
+      if (this.app.config.security.csrf.ignore) {
+        if (Array.isArray(this.app.config.security.csrf.ignore)) {
           this.app.config.security.csrf.ignore = [
+            /^\/mcp\//,
             this.app.config.mcp.sseInitPath,
             this.app.config.mcp.sseMessagePath,
             this.app.config.mcp.streamPath,
             this.app.config.mcp.statelessStreamPath,
+            ...(Array.isArray(this.app.config.security.csrf.ignore)
+              ? this.app.config.security.csrf.ignore
+              : [ this.app.config.security.csrf.ignore ]),
           ];
+        }
+      } else {
+        this.app.config.security.csrf.ignore = [
+          /^\/mcp\//,
+          this.app.config.mcp.sseInitPath,
+          this.app.config.mcp.sseMessagePath,
+          this.app.config.mcp.streamPath,
+          this.app.config.mcp.statelessStreamPath,
+        ];
+      }
+
+      if (this.app.config.mcp.multipleServer) {
+        for (const name of Object.keys(this.app.config.mcp.multipleServer)) {
+          [ 'sseInitPath', 'sseMessagePath', 'streamPath', 'statelessStreamPath' ].forEach(key => {
+            if (this.app.config.mcp.multipleServer[name][key]) this.app.config.security.csrf.ignore.push(this.app.config.mcp.multipleServer[name][key]);
+          });
         }
       }
     }
@@ -116,16 +135,12 @@ export default class ControllerAppBootHook {
   }
 
   async willReady() {
-    if (majorVersion >= 18 && (this.app.config.security.csrf || this.app.config.security.csrf.enable)) {
+    if (majorVersion >= 18) {
       await MCPControllerRegister.connectStatelessStreamTransport();
       const names = MCPControllerRegister.instance?.mcpConfig.getMultipleServerNames();
       if (names && names.length > 0) {
         for (const name of names) {
           await MCPControllerRegister.connectStatelessStreamTransport(name);
-          this.app.config.security.csrf.ignore.push(this.app.config.mcp.multipleServer[name].sseInitPath);
-          this.app.config.security.csrf.ignore.push(this.app.config.mcp.multipleServer[name].sseMessagePath);
-          this.app.config.security.csrf.ignore.push(this.app.config.mcp.multipleServer[name].streamPath);
-          this.app.config.security.csrf.ignore.push(this.app.config.mcp.multipleServer[name].statelessStreamPath);
         }
       }
     }

--- a/plugin/controller/test/fixtures/apps/controller-app/config/config.default.js
+++ b/plugin/controller/test/fixtures/apps/controller-app/config/config.default.js
@@ -6,7 +6,7 @@ module.exports = function() {
     security: {
       csrf: {
         ignoreJSON: false,
-      }
+      },
     },
   };
   return config;

--- a/plugin/controller/test/fixtures/apps/duplicate-proto-name-app/config/config.default.js
+++ b/plugin/controller/test/fixtures/apps/duplicate-proto-name-app/config/config.default.js
@@ -6,7 +6,7 @@ module.exports = function() {
     security: {
       csrf: {
         ignoreJSON: false,
-      }
+      },
     },
   };
   return config;

--- a/plugin/controller/test/fixtures/apps/http-conflict-app/config/config.default.js
+++ b/plugin/controller/test/fixtures/apps/http-conflict-app/config/config.default.js
@@ -6,7 +6,7 @@ module.exports = function() {
     security: {
       csrf: {
         ignoreJSON: false,
-      }
+      },
     },
   };
   return config;

--- a/plugin/controller/test/fixtures/apps/http-inject-app/config/config.default.js
+++ b/plugin/controller/test/fixtures/apps/http-inject-app/config/config.default.js
@@ -6,7 +6,7 @@ module.exports = function() {
     security: {
       csrf: {
         ignoreJSON: false,
-      }
+      },
     },
   };
   return config;

--- a/plugin/controller/test/fixtures/apps/mcp-app/config/config.default.js
+++ b/plugin/controller/test/fixtures/apps/mcp-app/config/config.default.js
@@ -5,9 +5,6 @@ const { randomUUID } = require('node:crypto');
 module.exports = function() {
   const config = {
     keys: 'test key',
-    security: {
-      csrf: false,
-    },
     mcp: {
       sessionIdGenerator: ctx => {
         return ctx.request.headers['custom-session-id'] || randomUUID();

--- a/plugin/controller/test/fixtures/apps/mcp-app/config/config.default.js
+++ b/plugin/controller/test/fixtures/apps/mcp-app/config/config.default.js
@@ -6,9 +6,7 @@ module.exports = function() {
   const config = {
     keys: 'test key',
     security: {
-      csrf: {
-        enable: false,
-      },
+      csrf: false,
     },
     mcp: {
       sessionIdGenerator: ctx => {
@@ -22,8 +20,8 @@ module.exports = function() {
           sessionIdGenerator: ctx => {
             return ctx.request.headers['custom-session-id'] || randomUUID();
           },
-        }
-      }
+        },
+      },
     },
   };
   return config;

--- a/plugin/controller/test/fixtures/apps/module-app/config/config.default.js
+++ b/plugin/controller/test/fixtures/apps/module-app/config/config.default.js
@@ -4,9 +4,7 @@ module.exports = function() {
   const config = {
     keys: 'test key',
     security: {
-      csrf: {
-        ignoreJSON: false,
-      },
+      csrf: false,
     },
     controller: {
       supportParams: true,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of CSRF configuration to ensure MCP-related paths are always included in the CSRF ignore list when CSRF protection is enabled.
  * Prevented unnecessary operations related to MCP paths and stateless stream transport when CSRF protection is disabled.

* **Chores**
  * Simplified CSRF configuration format and made minor formatting adjustments in configuration files.
  * Normalized CSRF configuration to consistently use an object format for better stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->