### PR TITLE
feat: allow inject MysqlDataSourceManager

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ 16, 18, 20, 22 ]
+        node-version: [ 16, 18, 20 ]
     steps:
     - name: Checkout Git Source
       uses: actions/checkout@master

--- a/core/tegg/dal.ts
+++ b/core/tegg/dal.ts
@@ -1,1 +1,2 @@
 export * from '@eggjs/dal-decorator';
+export * from '@eggjs/tegg-dal-plugin';

--- a/core/tegg/package.json
+++ b/core/tegg/package.json
@@ -54,6 +54,9 @@
     "@eggjs/tegg-transaction-decorator": "^3.60.1",
     "@eggjs/tegg-types": "^3.60.1"
   },
+  "peerDependencies": {
+    "@eggjs/tegg-dal-plugin": "^3.60.1"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/plugin/dal/app/extend/application.ts
+++ b/plugin/dal/app/extend/application.ts
@@ -1,4 +1,4 @@
-import { MysqlDataSourceManager } from '../lib/MysqlDataSourceManager';
+import { MysqlDataSourceManager } from '../../lib/MysqlDataSourceManager';
 
 export default {
   get mysqlDataSourceManager() {

--- a/plugin/dal/extends/application.ts
+++ b/plugin/dal/extends/application.ts
@@ -1,0 +1,7 @@
+import { MysqlDataSourceManager } from '../lib/MysqlDataSourceManager';
+
+export default {
+  mysqlDataSourceManager() {
+    return MysqlDataSourceManager.instance;
+  },
+};

--- a/plugin/dal/extends/application.ts
+++ b/plugin/dal/extends/application.ts
@@ -1,7 +1,7 @@
 import { MysqlDataSourceManager } from '../lib/MysqlDataSourceManager';
 
 export default {
-  mysqlDataSourceManager() {
+  get mysqlDataSourceManager() {
     return MysqlDataSourceManager.instance;
   },
 };

--- a/plugin/dal/index.ts
+++ b/plugin/dal/index.ts
@@ -1,0 +1,1 @@
+export { MysqlDataSourceManager } from './lib/MysqlDataSourceManager';

--- a/plugin/dal/package.json
+++ b/plugin/dal/package.json
@@ -12,6 +12,7 @@
   },
   "version": "3.60.1",
   "description": "dal plugin for egg",
+  "main": "index.js",
   "keywords": [
     "egg",
     "plugin",
@@ -23,13 +24,14 @@
   "files": [
     "app.js",
     "app.d.ts",
+    "index.js",
+    "index.d.ts",
     "lib/**/*.js",
     "lib/**/*.d.ts",
     "app/**/*.js",
     "app/**/*.d.ts",
     "typings/*.d.ts"
   ],
-  "types": "typings/index.d.ts",
   "scripts": {
     "test": "cross-env NODE_ENV=test NODE_OPTIONS='--no-deprecation' mocha",
     "clean": "tsc -b --clean",

--- a/plugin/dal/test/fixtures/apps/dal-app/modules/dal/FooService.ts
+++ b/plugin/dal/test/fixtures/apps/dal-app/modules/dal/FooService.ts
@@ -2,6 +2,7 @@ import { AccessLevel, Inject, SingletonProto } from '@eggjs/tegg';
 import { Transactional } from '@eggjs/tegg/transaction';
 import FooDAO from './dal/dao/FooDAO';
 import { Foo } from './Foo';
+import { MysqlDataSourceManager } from '../../../../../../lib/MysqlDataSourceManager';
 
 @SingletonProto({
   accessLevel: AccessLevel.PUBLIC,
@@ -9,6 +10,9 @@ import { Foo } from './Foo';
 export class FooService {
   @Inject()
   private readonly fooDAO: FooDAO;
+
+  @Inject()
+  private readonly mysqlDataSourceManager: MysqlDataSourceManager;
 
   @Transactional()
   async succeedTransaction() {
@@ -29,5 +33,9 @@ export class FooService {
     await this.fooDAO.insert(foo);
     await this.fooDAO.insert(foo2);
     throw new Error('mock error');
+  }
+
+  foo() {
+    return this.mysqlDataSourceManager;
   }
 }

--- a/standalone/standalone/src/Runner.ts
+++ b/standalone/standalone/src/Runner.ts
@@ -40,7 +40,7 @@ import { StandaloneContextHandler } from './StandaloneContextHandler';
 import { ConfigSourceLoadUnitHook } from './ConfigSourceLoadUnitHook';
 import { DalTableEggPrototypeHook } from '@eggjs/tegg-dal-plugin/lib/DalTableEggPrototypeHook';
 import { DalModuleLoadUnitHook } from '@eggjs/tegg-dal-plugin/lib/DalModuleLoadUnitHook';
-import { MysqlDataSourceManager } from '@eggjs/tegg-dal-plugin/lib/MysqlDataSourceManager';
+import { MysqlDataSourceManager } from '@eggjs/tegg-dal-plugin';
 import { SqlMapManager } from '@eggjs/tegg-dal-plugin/lib/SqlMapManager';
 import { TableModelManager } from '@eggjs/tegg-dal-plugin/lib/TableModelManager';
 import { TransactionPrototypeHook } from '@eggjs/tegg-dal-plugin/lib/TransactionPrototypeHook';
@@ -96,6 +96,9 @@ export class Runner {
         obj: new ModuleConfigs(this.moduleConfigs),
       }],
       moduleConfig: [],
+      mysqlDataSourceManager: [{
+        obj: MysqlDataSourceManager.instance,
+      }],
     };
 
     const runtimeConfig: Partial<RuntimeConfig> = {

--- a/standalone/standalone/test/fixtures/dal-module/src/main.ts
+++ b/standalone/standalone/test/fixtures/dal-module/src/main.ts
@@ -1,4 +1,5 @@
 import { ContextProto, Inject } from '@eggjs/tegg';
+import { MysqlDataSourceManager } from '@eggjs/tegg/dal';
 import { Runner, MainRunner } from '@eggjs/tegg/standalone';
 import FooDAO from './dal/dao/FooDAO';
 import { Foo } from './Foo';
@@ -9,6 +10,9 @@ import { Foo } from './Foo';
 export class FooRunner implements MainRunner<Foo | null> {
   @Inject()
   fooDAO: FooDAO;
+
+  @Inject()
+  mysqlDataSourceManager: MysqlDataSourceManager;
 
   async main(): Promise<Foo | null> {
     const foo = new Foo();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose a MySQL data source manager as a public, injectable singleton accessible from the app.
  * Enable root-level imports for the data source manager to simplify usage.

* **Refactor**
  * Updated internal usage to rely on the new root export.

* **Tests**
  * Expanded fixtures to inject and validate the data source manager.

* **Chores**
  * Declared the data source manager plugin as a peer dependency.
  * Updated package entry points and published files to include the new root exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->