### PR TITLE
fix(typings): fix getEggObjectFromName return type to Promise<T>

### DIFF
--- a/plugin/tegg/test/app/extend/application.test.ts
+++ b/plugin/tegg/test/app/extend/application.test.ts
@@ -38,4 +38,11 @@ describe('test/app/extend/application.test.ts', () => {
       }, /ctx is required/);
     });
   });
+
+  describe('getEggObjectFromName', () => {
+    it('should work with correct type inference', async () => {
+      const persistenceService: PersistenceService = await app.getEggObjectFromName<PersistenceService>('persistenceService');
+      assert(persistenceService instanceof PersistenceService);
+    });
+  });
 });

--- a/plugin/tegg/typings/index.d.ts
+++ b/plugin/tegg/typings/index.d.ts
@@ -60,7 +60,7 @@ declare module 'egg' {
     module: EggModule & EggApplicationModule;
 
     getEggObject<T>(clazz: EggProtoImplClass<T>, name?: string, qualifiers?: QualifierInfo | QualifierInfo[]): Promise<T>;
-    getEggObjectFromName<T>(name: string, qualifiers?: QualifierInfo | QualifierInfo[]): Promise<unknown>;
+    getEggObjectFromName<T>(name: string, qualifiers?: QualifierInfo | QualifierInfo[]): Promise<T>;
   }
 
   export interface TEggContext {


### PR DESCRIPTION
The return type was Promise<unknown> which caused loss of type information. Changed to Promise<T> to enable proper type inference with explicit type parameters.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced type inference for retrieving objects by name, allowing developers to specify expected types and receive improved TypeScript support with stronger type checking.

* **Tests**
  * Added comprehensive test coverage to verify correct type inference, type safety, and runtime behavior of the enhanced object retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->