### PR TITLE
feat: add AgentController support to standalone Runner

### DIFF
--- a/standalone/standalone/package.json
+++ b/standalone/standalone/package.json
@@ -47,8 +47,10 @@
     "@eggjs/tegg-dynamic-inject-runtime": "^3.72.0",
     "@eggjs/tegg-lifecycle": "^3.72.0",
     "@eggjs/tegg-loader": "^3.72.0",
+    "@eggjs/tegg-controller-plugin": "^3.72.0",
     "@eggjs/tegg-metadata": "^3.72.0",
-    "@eggjs/tegg-runtime": "^3.72.0"
+    "@eggjs/tegg-runtime": "^3.72.0",
+    "@eggjs/tegg-types": "^3.72.0"
   },
   "publishConfig": {
     "access": "public"

--- a/standalone/standalone/src/Runner.ts
+++ b/standalone/standalone/src/Runner.ts
@@ -1,6 +1,7 @@
 import { ModuleConfigUtil, ModuleReference, ReadModuleReferenceOptions, RuntimeConfig } from '@eggjs/tegg-common-util';
 import {
   EggPrototype,
+  EggPrototypeCreatorFactory,
   EggPrototypeLifecycleUtil, GlobalGraph,
   LoadUnit,
   LoadUnitFactory,
@@ -11,6 +12,7 @@ import {
   ContextHandler,
   EggContainerFactory,
   EggContext,
+  EggObjectFactory,
   EggObjectLifecycleUtil,
   LoadUnitInstance,
   LoadUnitInstanceFactory,
@@ -44,6 +46,9 @@ import { MysqlDataSourceManager } from '@eggjs/tegg-dal-plugin';
 import { SqlMapManager } from '@eggjs/tegg-dal-plugin/lib/SqlMapManager';
 import { TableModelManager } from '@eggjs/tegg-dal-plugin/lib/TableModelManager';
 import { TransactionPrototypeHook } from '@eggjs/tegg-dal-plugin/lib/TransactionPrototypeHook';
+import { AGENT_CONTROLLER_PROTO_IMPL_TYPE } from '@eggjs/tegg-types';
+import { AgentControllerProto } from '@eggjs/tegg-controller-plugin/lib/AgentControllerProto';
+import { AgentControllerObject } from '@eggjs/tegg-controller-plugin/lib/AgentControllerObject';
 
 export interface ModuleDependency extends ReadModuleReferenceOptions {
   baseDir: string;
@@ -179,6 +184,13 @@ export class Runner {
     EggPrototypeLifecycleUtil.registerLifecycle(this.dalTableEggPrototypeHook);
     EggPrototypeLifecycleUtil.registerLifecycle(this.transactionPrototypeHook);
     LoadUnitLifecycleUtil.registerLifecycle(this.dalModuleLoadUnitHook);
+
+    // AgentController support
+    EggPrototypeCreatorFactory.registerPrototypeCreator(
+      AGENT_CONTROLLER_PROTO_IMPL_TYPE, AgentControllerProto.createProto);
+    AgentControllerObject.setLogger(logger as any);
+    EggObjectFactory.registerEggObjectCreateMethod(
+      AgentControllerProto, AgentControllerObject.createObject);
   }
 
   async load() {


### PR DESCRIPTION
## Summary

- Register `AgentControllerProto.createProto` and `AgentControllerObject.createObject` in the standalone `Runner` constructor, mirroring the registration done in `@eggjs/tegg-controller-plugin/app.ts`
- Add `@eggjs/tegg-controller-plugin` and `@eggjs/tegg-types` as dependencies of `@eggjs/tegg-standalone`
- This enables `@AgentController` decorated classes to work in standalone mode (without the egg plugin lifecycle)

## Test plan

- [ ] Verify existing standalone tests still pass
- [ ] Create a standalone Runner with an `@AgentController` class and confirm it initializes correctly
- [ ] Verify that AgentRuntime delegate methods are properly installed on the controller instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to improve framework support and stability.
  * Enhanced internal initialization process for better component registration and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->