### PR TITLE
fix: remove egg module

### DIFF
--- a/core/standalone-decorator/src/event/EventHandler.ts
+++ b/core/standalone-decorator/src/event/EventHandler.ts
@@ -18,3 +18,10 @@ export const EventHandlerProto = (type: EventType[keyof EventType], params?: Sin
     SingletonProto(params)(clazz);
   };
 };
+
+export interface FetchEventLike {
+  type: string;
+  request: Request;
+  respondWith(response: Response | Promise<Response>): void;
+  waitUntil?(promise: Promise<unknown>): void;
+}

--- a/standalone/service-worker/index.ts
+++ b/standalone/service-worker/index.ts
@@ -1,7 +1,6 @@
 export * from './src/constants';
 export * from './src/types';
 export * from './src/ServiceWorkerApp';
-export * from './src/ServiceWorkerRunner';
 export * from './src/hook/ContextProtoLoadUnitHook';
 export * from './src/hook/ControllerPrototypeHook';
 export * from './src/hook/ControllerLoadUnitHook';

--- a/standalone/service-worker/package.json
+++ b/standalone/service-worker/package.json
@@ -1,10 +1,7 @@
 {
   "name": "@eggjs/tegg-service-worker",
   "description": "tegg service worker",
-  "eggModule": {
-    "name": "serviceWorker"
-  },
-  "version": "3.78.7",
+  "version": "3.78.3",
   "keywords": [
     "egg",
     "typescript",

--- a/standalone/service-worker/src/ServiceWorkerApp.ts
+++ b/standalone/service-worker/src/ServiceWorkerApp.ts
@@ -16,6 +16,10 @@ import { ControllerPrototypeHook } from './hook/ControllerPrototypeHook';
 import { ControllerLoadUnitHook } from './hook/ControllerLoadUnitHook';
 import { HTTPControllerRegister } from './http/HTTPControllerRegister';
 import { MCPControllerRegister } from './mcp/MCPControllerRegister';
+import { LoadUnitInnerClassHook } from './hook/LoadUnitInnerClassHook';
+import { ServiceWorkerRunner } from './ServiceWorkerRunner';
+import { StandaloneEggObjectFactory } from './StandaloneEggObjectFactory';
+import { FetchEventHandler } from './http/FetchEventHandler';
 
 export interface ServiceWorkerAppOptions {
   innerObjectHandlers?: RunnerOptions['innerObjectHandlers'];
@@ -31,6 +35,7 @@ export class ServiceWorkerApp {
   private readonly rootProtoManager: RootProtoManager;
   private readonly controllerMetadataManager: ControllerMetadataManager;
   private readonly controllerRegisterFactory: ControllerRegisterFactory;
+  private readonly loadUnitInnerClassHook: LoadUnitInnerClassHook;
 
   constructor(cwd: string, options?: ServiceWorkerAppOptions & RunnerOptions) {
     // Create shared objects
@@ -73,6 +78,10 @@ export class ServiceWorkerApp {
       innerObjectHandlers.httpclient = [{ obj: getDefaultHttpClient() }];
     }
 
+    this.loadUnitInnerClassHook = new LoadUnitInnerClassHook([ StandaloneEggObjectFactory, ServiceWorkerRunner, FetchEventHandler ]);
+
+    LoadUnitLifecycleUtil.registerLifecycle(this.loadUnitInnerClassHook);
+
     this.runner = new Runner(cwd, {
       ...options,
       dependencies: deps,
@@ -99,6 +108,7 @@ export class ServiceWorkerApp {
     // Unregister lifecycle hooks
     LoadUnitLifecycleUtil.deleteLifecycle(this.contextProtoLoadUnitHook);
     LoadUnitLifecycleUtil.deleteLifecycle(this.controllerLoadUnitHook);
+    LoadUnitLifecycleUtil.deleteLifecycle(this.loadUnitInnerClassHook);
     EggPrototypeLifecycleUtil.deleteLifecycle(this.controllerPrototypeHook);
 
     await this.runner.destroy();

--- a/standalone/service-worker/src/ServiceWorkerRunner.ts
+++ b/standalone/service-worker/src/ServiceWorkerRunner.ts
@@ -1,16 +1,24 @@
 import { SingletonProto, Inject, EggObjectFactory } from '@eggjs/tegg';
-import { Runner, AbstractEventHandler } from '@eggjs/tegg/standalone';
+import { Runner, AbstractEventHandler, FetchEventLike } from '@eggjs/tegg/standalone';
+import { ContextHandler } from '@eggjs/tegg/helper';
+import { ContextProtoProperty } from './constants';
 
 @Runner()
 @SingletonProto()
 export class ServiceWorkerRunner {
-  @Inject()
-  private readonly event: Event;
-  @Inject()
+  @Inject({ name: 'standaloneEggObjectFactory' })
   private readonly eggObjectFactory: EggObjectFactory;
 
   async main(): Promise<unknown> {
-    const handler = await this.eggObjectFactory.getEggObject(AbstractEventHandler, this.event.type);
-    return await handler.handleEvent(this.event);
+    const requestContext = ContextHandler.getContext();
+    if (!requestContext) {
+      throw new Error('[tegg-standalone-framework] no request context in FetchRunner');
+    }
+    const event = requestContext.get(ContextProtoProperty.Event.contextKey) as FetchEventLike | undefined;
+    if (!event) {
+      throw new Error('[tegg-standalone-framework] no fetch event on context');
+    }
+    const handler = await this.eggObjectFactory.getEggObject(AbstractEventHandler, event.type);
+    return await handler.handleEvent(event);
   }
 }

--- a/standalone/service-worker/src/StandaloneEggObjectFactory.ts
+++ b/standalone/service-worker/src/StandaloneEggObjectFactory.ts
@@ -1,0 +1,11 @@
+import { AccessLevel, SingletonProto } from '@eggjs/tegg';
+import { EggObjectFactory } from '@eggjs/tegg-dynamic-inject-runtime';
+import {
+  EGG_OBJECT_FACTORY_PROTO_IMPLE_TYPE,
+} from '@eggjs/tegg-dynamic-inject-runtime/src/EggObjectFactoryPrototype';
+
+@SingletonProto({
+  protoImplType: EGG_OBJECT_FACTORY_PROTO_IMPLE_TYPE,
+  accessLevel: AccessLevel.PRIVATE,
+})
+export class StandaloneEggObjectFactory extends EggObjectFactory {}

--- a/standalone/service-worker/src/hook/LoadUnitInnerClassHook.ts
+++ b/standalone/service-worker/src/hook/LoadUnitInnerClassHook.ts
@@ -1,0 +1,22 @@
+import { EggProtoImplClass, LifecycleHook } from '@eggjs/tegg';
+import { EggPrototypeCreatorFactory, EggPrototypeFactory } from '@eggjs/tegg/helper';
+import type { LoadUnit, LoadUnitLifecycleContext } from '@eggjs/tegg/helper';
+
+export class LoadUnitInnerClassHook implements LifecycleHook<LoadUnitLifecycleContext, LoadUnit> {
+  private readonly innerClasses: EggProtoImplClass[];
+
+  constructor(innerClasses: EggProtoImplClass[]) {
+    this.innerClasses = innerClasses;
+  }
+
+  async postCreate(_: LoadUnitLifecycleContext, loadUnit: LoadUnit): Promise<void> {
+    if (loadUnit.type === 'StandaloneLoadUnitType') {
+      for (const clazz of this.innerClasses) {
+        const protos = await EggPrototypeCreatorFactory.createProto(clazz, loadUnit);
+        for (const proto of protos) {
+          EggPrototypeFactory.instance.registerPrototype(proto, loadUnit);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package version updated to 3.78.3; removed legacy module declaration from the package manifest.
  * Removed the package entry-point export for ServiceWorkerRunner (no longer accessible via the main package entry).
* **Refactor**
  * Internal lifecycle and runtime behavior updated: added lifecycle registration, context-driven event handling, and a standalone object factory for improved runtime management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->