### PR TITLE
fix(agent-runtime): persist thread messages when a run is aborted

### DIFF
--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -127,12 +127,13 @@ export class AgentRuntime {
     });
     this.runningTasks.set(run.id, { promise: taskPromise, abortController });
 
+    const streamMessages: AgentMessage[] = [];
     try {
       await this.store.updateRun(run.id, rb.start());
 
-      const streamMessages: AgentMessage[] = [];
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
+          await this.persistMessagesOnAbort(threadId, input, streamMessages);
           const latest = await this.store.getRun(run.id);
           return RunBuilder.fromRecord(latest).snapshot();
         }
@@ -152,6 +153,7 @@ export class AgentRuntime {
       return rb.snapshot();
     } catch (err: unknown) {
       if (abortController.signal.aborted) {
+        await this.persistMessagesOnAbort(threadId, input, streamMessages);
         const latest = await this.store.getRun(run.id);
         return RunBuilder.fromRecord(latest).snapshot();
       }
@@ -187,12 +189,15 @@ export class AgentRuntime {
     this.runningTasks.set(run.id, { promise: taskPromise, abortController });
 
     (async () => {
+      const streamMessages: AgentMessage[] = [];
       try {
         await this.store.updateRun(run.id, rb.start());
 
-        const streamMessages: AgentMessage[] = [];
         for await (const msg of this.executor.execRun(input, abortController.signal)) {
-          if (abortController.signal.aborted) return;
+          if (abortController.signal.aborted) {
+            await this.persistMessagesOnAbort(threadId, input, streamMessages);
+            return;
+          }
           streamMessages.push(msg);
         }
 
@@ -222,6 +227,7 @@ export class AgentRuntime {
             this.logger.error('[AgentRuntime] failed to update run status after error:', storeErr);
           }
         } else {
+          await this.persistMessagesOnAbort(threadId, input, streamMessages);
           this.logger.error('[AgentRuntime] execRun error during abort:', err);
         }
       } finally {
@@ -326,13 +332,13 @@ export class AgentRuntime {
     buffer: RunEventBuffer,
     abortController: AbortController,
   ): Promise<void> {
+    const streamMessages: AgentMessage[] = [];
     try {
       await this.store.updateRun(runId, rb.start());
 
-      const streamMessages: AgentMessage[] = [];
-
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
+          await this.persistMessagesOnAbort(threadId, input, streamMessages);
           this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
           return;
         }
@@ -347,6 +353,7 @@ export class AgentRuntime {
       // Check if another worker has cancelled this run before writing final state
       const currentRun = await this.store.getRun(runId);
       if (currentRun.status === RunStatus.Cancelling || currentRun.status === RunStatus.Cancelled) {
+        await this.persistMessagesOnAbort(threadId, input, streamMessages);
         this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
         return;
       }
@@ -372,12 +379,38 @@ export class AgentRuntime {
         }
         this.pushEvent(buffer, 'error', { message: (err as Error).message, runId });
       } else {
+        await this.persistMessagesOnAbort(threadId, input, streamMessages);
         this.logger.error('[AgentRuntime] execRun error during abort:', err);
         this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
       }
     } finally {
       buffer.done = true;
       buffer.emitter.emit('event');
+    }
+  }
+
+  /**
+   * Persist input + collected stream messages to the thread when a run is
+   * aborted. Keeping the thread in sync with any partial state that the
+   * executor has already written (e.g. Claude CLI session file) is what
+   * allows subsequent resume requests to continue from a consistent history
+   * instead of diverging and failing at executor startup.
+   *
+   * Errors are swallowed here so a store failure cannot mask the abort or
+   * prevent cancelRun from finalising the run status.
+   */
+  private async persistMessagesOnAbort(
+    threadId: string,
+    input: CreateRunInput,
+    streamMessages: AgentMessage[],
+  ): Promise<void> {
+    try {
+      await this.store.appendMessages(threadId, [
+        ...MessageConverter.toAgentMessages(input.input.messages),
+        ...MessageConverter.filterForStorage(streamMessages),
+      ]);
+    } catch (err) {
+      this.logger.error('[AgentRuntime] failed to persist messages on abort:', err);
     }
   }
 

--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -134,6 +134,7 @@ export class AgentRuntime {
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
           await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          await this.finaliseAbortedRun(run.id);
           const latest = await this.store.getRun(run.id);
           return RunBuilder.fromRecord(latest).snapshot();
         }
@@ -154,6 +155,7 @@ export class AgentRuntime {
     } catch (err: unknown) {
       if (abortController.signal.aborted) {
         await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        await this.finaliseAbortedRun(run.id);
         const latest = await this.store.getRun(run.id);
         return RunBuilder.fromRecord(latest).snapshot();
       }
@@ -196,6 +198,7 @@ export class AgentRuntime {
         for await (const msg of this.executor.execRun(input, abortController.signal)) {
           if (abortController.signal.aborted) {
             await this.persistMessagesOnAbort(threadId, input, streamMessages);
+            await this.finaliseAbortedRun(run.id);
             return;
           }
           streamMessages.push(msg);
@@ -228,6 +231,7 @@ export class AgentRuntime {
           }
         } else {
           await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          await this.finaliseAbortedRun(run.id);
           this.logger.error('[AgentRuntime] execRun error during abort:', err);
         }
       } finally {
@@ -339,6 +343,7 @@ export class AgentRuntime {
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
           await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          await this.finaliseAbortedRun(runId);
           this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
           return;
         }
@@ -380,6 +385,7 @@ export class AgentRuntime {
         this.pushEvent(buffer, 'error', { message: (err as Error).message, runId });
       } else {
         await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        await this.finaliseAbortedRun(runId);
         this.logger.error('[AgentRuntime] execRun error during abort:', err);
         this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
       }
@@ -411,6 +417,34 @@ export class AgentRuntime {
       ]);
     } catch (err) {
       this.logger.error('[AgentRuntime] failed to persist messages on abort:', err);
+    }
+  }
+
+  /**
+   * Push an aborted run to a terminal `cancelled` state when nobody else
+   * will. Abort can be driven either by `cancelRun` — which already owns
+   * the `in_progress → cancelling → cancelled` transition — or by an
+   * external `AbortSignal` / `destroy()`, where the run would otherwise
+   * stay stuck in `in_progress` forever.
+   *
+   * Behaviour:
+   * - terminal status (completed/failed/cancelled/expired): no-op.
+   * - `cancelling`: no-op, let `cancelRun` finish the transition.
+   * - `in_progress` / `queued`: write `cancelling` then `cancelled`.
+   *
+   * Errors are swallowed so a store failure cannot mask the abort.
+   */
+  private async finaliseAbortedRun(runId: string): Promise<void> {
+    try {
+      const current = await this.store.getRun(runId);
+      if (AgentRuntime.TERMINAL_RUN_STATUSES.has(current.status)) return;
+      if (current.status === RunStatus.Cancelling) return;
+
+      const rb = RunBuilder.fromRecord(current);
+      await this.store.updateRun(runId, rb.cancelling());
+      await this.store.updateRun(runId, rb.cancel());
+    } catch (err) {
+      this.logger.error('[AgentRuntime] failed to finalise aborted run:', err);
     }
   }
 

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -798,4 +798,187 @@ describe('test/AgentRuntime.test.ts', () => {
       assert.equal(cancelResult.status, RunStatus.Completed);
     });
   });
+
+  describe('abort message persistence', () => {
+    // Rationale: when an executor supports resuming from a session file
+    // (e.g. Claude CLI session), aborts leave partial state in that session.
+    // If the thread is NOT updated with the same partial state, any
+    // subsequent resume request diverges from the executor's view of history
+    // and can fail at executor startup. These tests pin down that abort
+    // writes the same messages to the thread that the executor has already
+    // observed.
+
+    async function waitUntil(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+      const start = Date.now();
+      while (!cond()) {
+        if (Date.now() - start > timeoutMs) throw new Error('waitUntil timeout');
+        await setTimeout(10);
+      }
+    }
+
+    it('syncRun: should persist user + partial assistant messages when aborted via signal', async () => {
+      let yielded = false;
+      executor.execRun = createSlowExecRun(
+        [{ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } }],
+        () => { yielded = true; },
+      );
+
+      const thread = await runtime.createThread();
+      const ac = new AbortController();
+      const syncPromise = runtime.syncRun(
+        { threadId: thread.id, input: { messages: [{ role: 'user', content: 'Hi' }] } },
+        ac.signal,
+      );
+
+      await waitUntil(() => yielded);
+      ac.abort();
+      const result = await syncPromise;
+      assert.equal(result.threadId, thread.id);
+
+      const updated = await runtime.getThread(thread.id);
+      assert.equal(updated.messages.length, 2);
+      assert.equal(updated.messages[0].type, 'user');
+      assert.equal(updated.messages[1].type, 'assistant');
+      assert.deepStrictEqual(
+        (updated.messages[1].message as { content: unknown }).content,
+        [{ type: 'text', text: 'partial' }],
+      );
+    });
+
+    it('syncRun: should persist only the user message when aborted before any chunk', async () => {
+      const resolveRef: { resolve?: () => void } = {};
+      executor.execRun = createBlockingExecRun(resolveRef, [
+        { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'never' }] } },
+      ]);
+
+      const thread = await runtime.createThread();
+      const ac = new AbortController();
+      const syncPromise = runtime.syncRun(
+        { threadId: thread.id, input: { messages: [{ role: 'user', content: 'Hi' }] } },
+        ac.signal,
+      );
+
+      // Give syncRun time to enter the await on the executor
+      await setTimeout(20);
+      ac.abort();
+      await syncPromise;
+
+      const updated = await runtime.getThread(thread.id);
+      assert.equal(updated.messages.length, 1);
+      assert.equal(updated.messages[0].type, 'user');
+    });
+
+    it('asyncRun: should persist user + partial assistant messages when aborted via cancelRun', async () => {
+      let yielded = false;
+      executor.execRun = createSlowExecRun(
+        [{ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } }],
+        () => { yielded = true; },
+      );
+
+      const thread = await runtime.createThread();
+      const result = await runtime.asyncRun({
+        threadId: thread.id,
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+
+      await waitUntil(() => yielded);
+      await runtime.cancelRun(result.id);
+
+      const updated = await runtime.getThread(thread.id);
+      assert.equal(updated.messages.length, 2);
+      assert.equal(updated.messages[0].type, 'user');
+      assert.equal(updated.messages[1].type, 'assistant');
+    });
+
+    it('streamRun: should persist user + partial assistant messages when aborted via cancelRun', async () => {
+      let yielded = false;
+      executor.execRun = createSlowExecRun(
+        [{ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } }],
+        () => { yielded = true; },
+      );
+
+      const thread = await runtime.createThread();
+      const writer = new MockSSEWriter();
+      const streamPromise = runtime.streamRun(
+        { threadId: thread.id, input: { messages: [{ role: 'user', content: 'Hi' }] } },
+        writer,
+      );
+
+      await waitUntil(() => yielded);
+      // Wait for run_created event to land so we can read the runId
+      await waitUntil(() => writer.events.some(e => e.event === 'run_created'));
+      const runCreated = writer.events.find(e => e.event === 'run_created')!;
+      const runId = ((runCreated.data as StreamEvent).data as { runId: string }).runId;
+
+      await runtime.cancelRun(runId);
+      writer.simulateClose();
+      await streamPromise;
+
+      const updated = await runtime.getThread(thread.id);
+      assert.equal(updated.messages.length, 2);
+      assert.equal(updated.messages[0].type, 'user');
+      assert.equal(updated.messages[1].type, 'assistant');
+    });
+
+    it('should set isResume=true on the next run after an abort (regression: abort+continue)', async () => {
+      // Reproduces the bug: user aborts turn N, then sends turn N+1. Before the fix, turn N's
+      // messages were never persisted, so the second call's isResume depended only on earlier
+      // completed turns — and any divergence from the executor's session caused subsequent
+      // resume attempts to fail.
+      let yielded = false;
+      executor.execRun = createSlowExecRun(
+        [{ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } }],
+        () => { yielded = true; },
+      );
+
+      const thread = await runtime.createThread();
+      const ac = new AbortController();
+      const firstPromise = runtime.syncRun(
+        { threadId: thread.id, input: { messages: [{ role: 'user', content: 'Hi' }] } },
+        ac.signal,
+      );
+      await waitUntil(() => yielded);
+      ac.abort();
+      await firstPromise;
+
+      let capturedInput: CreateRunInput | undefined;
+      executor.execRun = async function* (input: CreateRunInput): AsyncGenerator<AgentMessage> {
+        capturedInput = input;
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] } };
+      };
+      await runtime.syncRun({
+        threadId: thread.id,
+        input: { messages: [{ role: 'user', content: 'continue' }] },
+      });
+      assert.equal(capturedInput!.isResume, true);
+    });
+
+    it('should swallow store.appendMessages errors during abort cleanup', async () => {
+      let yielded = false;
+      executor.execRun = createSlowExecRun(
+        [{ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } }],
+        () => { yielded = true; },
+      );
+
+      const thread = await runtime.createThread();
+      const origAppend = store.appendMessages.bind(store);
+      store.appendMessages = async () => {
+        throw new Error('store down');
+      };
+
+      const ac = new AbortController();
+      const syncPromise = runtime.syncRun(
+        { threadId: thread.id, input: { messages: [{ role: 'user', content: 'Hi' }] } },
+        ac.signal,
+      );
+      await waitUntil(() => yielded);
+      ac.abort();
+      // Should resolve with a snapshot instead of rejecting
+      const result = await syncPromise;
+      assert(result.id.startsWith('run_'));
+
+      // Thread append failed — state is empty, but the abort path completed cleanly
+      store.appendMessages = origAppend;
+    });
+  });
 });

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -946,11 +946,83 @@ describe('test/AgentRuntime.test.ts', () => {
         capturedInput = input;
         yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] } };
       };
-      await runtime.syncRun({
+      const secondResult = await runtime.syncRun({
         threadId: thread.id,
         input: { messages: [{ role: 'user', content: 'continue' }] },
       });
       assert.equal(capturedInput!.isResume, true);
+      assert.equal(capturedInput!.input.messages[0].content, 'continue');
+      assert.equal(secondResult.status, RunStatus.Completed);
+    });
+
+    it('syncRun: should finalise run status to Cancelled when aborted via external signal (no cancelRun)', async () => {
+      let yielded = false;
+      executor.execRun = createSlowExecRun(
+        [{ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } }],
+        () => { yielded = true; },
+      );
+
+      const thread = await runtime.createThread();
+      const ac = new AbortController();
+      const syncPromise = runtime.syncRun(
+        { threadId: thread.id, input: { messages: [{ role: 'user', content: 'Hi' }] } },
+        ac.signal,
+      );
+      await waitUntil(() => yielded);
+      ac.abort();
+      const snapshot = await syncPromise;
+
+      // Snapshot reflects the live store state after finalisation
+      assert.equal(snapshot.status, RunStatus.Cancelled);
+      const persisted = await store.getRun(snapshot.id);
+      assert.equal(persisted.status, RunStatus.Cancelled);
+      assert(persisted.cancelledAt);
+    });
+
+    it('asyncRun: should finalise run status to Cancelled when destroy() aborts in-flight runs', async () => {
+      const resolveRef: { resolve?: () => void } = {};
+      executor.execRun = createBlockingExecRun(resolveRef, [
+        { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'never' }] } },
+      ]);
+
+      const result = await runtime.asyncRun({
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      await waitForRunStatus(store, result.id, RunStatus.InProgress);
+
+      await runtime.destroy();
+
+      const persisted = await store.getRun(result.id);
+      assert.equal(persisted.status, RunStatus.Cancelled);
+    });
+
+    it('should preserve cancelling → cancelled ordering when cancelRun drives the abort', async () => {
+      // Regression guard for the finaliseAbortedRun addition: our in-branch
+      // finaliser must NOT write when cancelRun has already set `cancelling`,
+      // otherwise cancelRun's own `cancel()` transition would throw.
+      executor.execRun = createSlowExecRun([
+        { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } },
+      ]);
+
+      const statusHistory: string[] = [];
+      const origUpdateRun = store.updateRun.bind(store);
+      store.updateRun = async (runId: string, updates: Partial<RunRecord>) => {
+        if (updates.status) statusHistory.push(updates.status);
+        return origUpdateRun(runId, updates);
+      };
+
+      const asyncResult = await runtime.asyncRun({
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      await waitForRunStatus(store, asyncResult.id, RunStatus.InProgress);
+      statusHistory.length = 0;
+
+      await runtime.cancelRun(asyncResult.id);
+
+      const cancellingWrites = statusHistory.filter(s => s === RunStatus.Cancelling).length;
+      const cancelledWrites = statusHistory.filter(s => s === RunStatus.Cancelled).length;
+      assert.equal(cancellingWrites, 1, 'cancelling should be written exactly once (by cancelRun)');
+      assert.equal(cancelledWrites, 1, 'cancelled should be written exactly once (by cancelRun)');
     });
 
     it('should swallow store.appendMessages errors during abort cleanup', async () => {


### PR DESCRIPTION
## Summary

When a run is aborted mid-stream, `AgentRuntime` returns early without persisting the user input or any partial executor output to the thread. For executors that keep their own session state (e.g. the Claude CLI session file), this leaves the thread diverged from the executor's view of history — the executor has `[user_N, partial_assistant_N]` written, but the thread only has turns `1..N-1`.

On the next request, `ensureThread` still reports `isResume=true` (thread has older turns), the executor is invoked with `resume=<sessionId>`, and startup can fail because the two histories no longer match.

This change calls `appendMessages` in every abort path so the thread reflects the same user + streamMessages the executor has already observed. Subsequent resume requests start from a consistent history and can continue the conversation — matching the local Claude Code ESC-then-continue behaviour.

## Changes

- `syncRun`: persist on both the `signal.aborted` early-return inside the loop and the `catch` branch where the executor throws after abort.
- `asyncRun`: same two paths inside the background IIFE.
- `executeStreamBackground`: same two paths, plus the cross-worker `Cancelling/Cancelled` check after the loop completes normally.
- New private helper `persistMessagesOnAbort` centralises the append and swallows store errors so a failing store cannot mask the abort or block `cancelRun` from finalising the run status.

## Test plan

- [x] 6 new cases in `AgentRuntime.test.ts` under `abort message persistence`:
  - `syncRun` / `asyncRun` / `streamRun`: persist user + partial assistant on abort
  - `syncRun`: persist only user message when aborted before any chunk is yielded
  - regression: `isResume=true` on the next run after an abort
  - `store.appendMessages` failure during abort cleanup does not throw
- [x] Full suite: 122 passing (116 existing + 6 new), no regressions.
- [x] `tsc` and eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted runs: User and assistant messages are now reliably persisted when runs are aborted or cancelled, preventing message loss.
  * Partial assistant responses generated before interruption are preserved to maintain accurate conversation history.

* **Tests**
  * Added comprehensive tests for message persistence across abort and cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->