### PR TITLE
fix(agent-runtime): hold cancelRun until executor session is committed

### DIFF
--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -14,7 +14,13 @@ import type {
   AgentStore,
   StreamEvent,
 } from '@eggjs/tegg-types/agent-runtime';
-import { RunStatus, AgentObjectType, AgentConflictError, AgentNotFoundError } from '@eggjs/tegg-types/agent-runtime';
+import {
+  RunStatus,
+  AgentObjectType,
+  AgentConflictError,
+  AgentNotFoundError,
+  AgentTimeoutError,
+} from '@eggjs/tegg-types/agent-runtime';
 import type { EggLogger } from 'egg-logger';
 
 import { MessageConverter } from './MessageConverter';
@@ -23,6 +29,7 @@ import type { SSEWriter } from './SSEWriter';
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const EVENT_DIR = join(tmpdir(), 'agent-runtime-events');
+const DEFAULT_CANCEL_COMMIT_TIMEOUT_MS = 30_000;
 
 interface RunEventBuffer {
   filePath: string;
@@ -34,17 +41,41 @@ interface RunEventBuffer {
 export const AGENT_RUNTIME: unique symbol = Symbol('agentRuntime');
 
 /**
- * The executor interface — only requires execRun so the runtime can delegate
+ * The executor interface — execRun is required so the runtime can delegate
  * execution back through the controller's prototype chain (AOP/mock friendly).
+ *
+ * `isSessionCommitted` is an optional hook that lets the executor tell the
+ * runtime when its underlying session has been persisted to storage (e.g. the
+ * Claude Code SDK jsonl file). The runtime uses this to decide when a pending
+ * `cancelRun` can safely abort and persist the thread. See AgentHandler.ts
+ * for the semantics and the default heuristic used when this hook is absent.
  */
 export interface AgentExecutor {
   execRun(input: CreateRunInput, signal?: AbortSignal): AsyncGenerator<AgentMessage>;
+  isSessionCommitted?(msg: AgentMessage, history: AgentMessage[]): boolean | Promise<boolean>;
 }
 
 export interface AgentRuntimeOptions {
   executor: AgentExecutor;
   store: AgentStore;
   logger: EggLogger;
+  /**
+   * How long cancelRun should wait for the executor's session to become
+   * committed before giving up and marking the run as failed. Defaults to
+   * 30 seconds.
+   */
+  cancelCommitTimeoutMs?: number;
+}
+
+interface RunTaskState {
+  promise: Promise<void>;
+  abortController: AbortController;
+  /** True once the executor has reported (or the heuristic has detected) that
+   *  its session is safely persisted and the run can be cancelled cleanly. */
+  committed: boolean;
+  /** Emits 'commit' the first time committed flips to true, and 'end' when the
+   *  task's execution finally finishes (success, failure, or abort). */
+  emitter: EventEmitter;
 }
 
 export class AgentRuntime {
@@ -56,10 +87,11 @@ export class AgentRuntime {
   ]);
 
   private store: AgentStore;
-  private runningTasks: Map<string, { promise: Promise<void>; abortController: AbortController }>;
+  private runningTasks: Map<string, RunTaskState>;
   private runBuffers: Map<string, RunEventBuffer>;
   private executor: AgentExecutor;
   private logger: EggLogger;
+  private cancelCommitTimeoutMs: number;
 
   constructor(options: AgentRuntimeOptions) {
     this.executor = options.executor;
@@ -68,6 +100,7 @@ export class AgentRuntime {
       throw new Error('AgentRuntimeOptions.logger is required');
     }
     this.logger = options.logger;
+    this.cancelCommitTimeoutMs = options.cancelCommitTimeoutMs ?? DEFAULT_CANCEL_COMMIT_TIMEOUT_MS;
     this.runningTasks = new Map();
     this.runBuffers = new Map();
   }
@@ -125,7 +158,13 @@ export class AgentRuntime {
     const taskPromise = new Promise<void>(r => {
       resolveTask = r;
     });
-    this.runningTasks.set(run.id, { promise: taskPromise, abortController });
+    const task: RunTaskState = {
+      promise: taskPromise,
+      abortController,
+      committed: false,
+      emitter: new EventEmitter(),
+    };
+    this.runningTasks.set(run.id, task);
 
     const streamMessages: AgentMessage[] = [];
     try {
@@ -133,12 +172,15 @@ export class AgentRuntime {
 
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
-          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          if (task.committed) {
+            await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          }
           await this.finaliseAbortedRun(run.id);
           const latest = await this.store.getRun(run.id);
           return RunBuilder.fromRecord(latest).snapshot();
         }
         streamMessages.push(msg);
+        await this.markCommittedIfNeeded(task, msg, streamMessages);
       }
 
       const usage = MessageConverter.extractUsage(streamMessages);
@@ -154,7 +196,9 @@ export class AgentRuntime {
       return rb.snapshot();
     } catch (err: unknown) {
       if (abortController.signal.aborted) {
-        await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        if (task.committed) {
+          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        }
         await this.finaliseAbortedRun(run.id);
         const latest = await this.store.getRun(run.id);
         return RunBuilder.fromRecord(latest).snapshot();
@@ -166,6 +210,7 @@ export class AgentRuntime {
       }
       throw err;
     } finally {
+      task.emitter.emit('end');
       resolveTask();
       this.runningTasks.delete(run.id);
     }
@@ -188,7 +233,13 @@ export class AgentRuntime {
     const taskPromise = new Promise<void>(r => {
       resolveTask = r;
     });
-    this.runningTasks.set(run.id, { promise: taskPromise, abortController });
+    const task: RunTaskState = {
+      promise: taskPromise,
+      abortController,
+      committed: false,
+      emitter: new EventEmitter(),
+    };
+    this.runningTasks.set(run.id, task);
 
     (async () => {
       const streamMessages: AgentMessage[] = [];
@@ -197,11 +248,14 @@ export class AgentRuntime {
 
         for await (const msg of this.executor.execRun(input, abortController.signal)) {
           if (abortController.signal.aborted) {
-            await this.persistMessagesOnAbort(threadId, input, streamMessages);
+            if (task.committed) {
+              await this.persistMessagesOnAbort(threadId, input, streamMessages);
+            }
             await this.finaliseAbortedRun(run.id);
             return;
           }
           streamMessages.push(msg);
+          await this.markCommittedIfNeeded(task, msg, streamMessages);
         }
 
         // Check if another worker has cancelled this run before writing final state
@@ -230,11 +284,14 @@ export class AgentRuntime {
             this.logger.error('[AgentRuntime] failed to update run status after error:', storeErr);
           }
         } else {
-          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          if (task.committed) {
+            await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          }
           await this.finaliseAbortedRun(run.id);
           this.logger.error('[AgentRuntime] execRun error during abort:', err);
         }
       } finally {
+        task.emitter.emit('end');
         resolveTask();
         this.runningTasks.delete(run.id);
       }
@@ -276,10 +333,17 @@ export class AgentRuntime {
     const taskPromise = new Promise<void>(r => {
       resolveTask = r;
     });
-    this.runningTasks.set(run.id, { promise: taskPromise, abortController });
+    const task: RunTaskState = {
+      promise: taskPromise,
+      abortController,
+      committed: false,
+      emitter: new EventEmitter(),
+    };
+    this.runningTasks.set(run.id, task);
 
-    this.executeStreamBackground(input, run.id, threadId, rb, buffer, abortController)
+    this.executeStreamBackground(input, run.id, threadId, rb, buffer, task)
       .finally(() => {
+        task.emitter.emit('end');
         resolveTask();
         this.runningTasks.delete(run.id);
         this.runBuffers.delete(run.id);
@@ -334,15 +398,18 @@ export class AgentRuntime {
     threadId: string,
     rb: RunBuilder,
     buffer: RunEventBuffer,
-    abortController: AbortController,
+    task: RunTaskState,
   ): Promise<void> {
+    const abortController = task.abortController;
     const streamMessages: AgentMessage[] = [];
     try {
       await this.store.updateRun(runId, rb.start());
 
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
-          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          if (task.committed) {
+            await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          }
           await this.finaliseAbortedRun(runId);
           this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
           return;
@@ -353,12 +420,16 @@ export class AgentRuntime {
         // Pass through SDK message directly as event data
         const eventType = msg.type || 'message';
         this.pushEvent(buffer, eventType, msg);
+
+        await this.markCommittedIfNeeded(task, msg, streamMessages);
       }
 
       // Check if another worker has cancelled this run before writing final state
       const currentRun = await this.store.getRun(runId);
       if (currentRun.status === RunStatus.Cancelling || currentRun.status === RunStatus.Cancelled) {
-        await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        if (task.committed) {
+          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        }
         this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
         return;
       }
@@ -384,7 +455,9 @@ export class AgentRuntime {
         }
         this.pushEvent(buffer, 'error', { message: (err as Error).message, runId });
       } else {
-        await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        if (task.committed) {
+          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        }
         await this.finaliseAbortedRun(runId);
         this.logger.error('[AgentRuntime] execRun error during abort:', err);
         this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
@@ -396,11 +469,78 @@ export class AgentRuntime {
   }
 
   /**
+   * Flip the task's `committed` flag the first time the executor's current
+   * message indicates its session has been persisted to storage. Uses the
+   * executor's `isSessionCommitted` hook when available, otherwise a default
+   * heuristic where any message with `type !== 'system'` counts as committed
+   * (the Claude Code SDK writes the jsonl around the first non-system event).
+   */
+  private async markCommittedIfNeeded(
+    task: RunTaskState,
+    msg: AgentMessage,
+    history: AgentMessage[],
+  ): Promise<void> {
+    if (task.committed) return;
+    let committed: boolean;
+    try {
+      committed = typeof this.executor.isSessionCommitted === 'function'
+        ? await this.executor.isSessionCommitted(msg, history)
+        : msg.type !== 'system';
+    } catch (err) {
+      this.logger.error('[AgentRuntime] isSessionCommitted threw, treating as not committed:', err);
+      committed = false;
+    }
+    if (committed) {
+      task.committed = true;
+      task.emitter.emit('commit');
+    }
+  }
+
+  /**
+   * Wait until the task reports that its session is committed, or the task
+   * finishes on its own, or the timeout elapses. Rejects with
+   * AgentTimeoutError on timeout. Resolves without error when the task ends
+   * before committing — in that case the caller should re-read the run's
+   * terminal status rather than trying to cancel further.
+   */
+  private waitForCommitted(task: RunTaskState, timeoutMs: number): Promise<void> {
+    if (task.committed) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const timer = globalThis.setTimeout(() => {
+        cleanup();
+        reject(new AgentTimeoutError(
+          `Timed out waiting ${timeoutMs}ms for executor session to be committed before cancel`,
+        ));
+      }, timeoutMs);
+      const onCommit = (): void => {
+        cleanup();
+        resolve();
+      };
+      const onEnd = (): void => {
+        cleanup();
+        resolve();
+      };
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        task.emitter.off('commit', onCommit);
+        task.emitter.off('end', onEnd);
+      };
+      task.emitter.once('commit', onCommit);
+      task.emitter.once('end', onEnd);
+    });
+  }
+
+  /**
    * Persist input + collected stream messages to the thread when a run is
    * aborted. Keeping the thread in sync with any partial state that the
    * executor has already written (e.g. Claude CLI session file) is what
    * allows subsequent resume requests to continue from a consistent history
    * instead of diverging and failing at executor startup.
+   *
+   * Callers must check `task.committed` before invoking this; if the
+   * executor never reached a committed state the thread should be left
+   * untouched so the next run starts fresh instead of trying to resume a
+   * session that was never created on disk.
    *
    * Errors are swallowed here so a store failure cannot mask the abort or
    * prevent cancelRun from finalising the run status.
@@ -540,6 +680,19 @@ export class AgentRuntime {
     return RunBuilder.fromRecord(run).snapshot();
   }
 
+  /**
+   * Cancel a running task. The call blocks until either (a) the executor
+   * reports its session is safely committed to storage, and the task has
+   * been aborted and the thread persisted, or (b) the commit watchdog times
+   * out, in which case the run is marked `failed` (not `cancelled`) and
+   * AgentTimeoutError is thrown to the caller.
+   *
+   * The hold is there to guarantee that whatever user input the thread
+   * records on abort is also present in the executor's own persistent
+   * session (e.g. Claude Code SDK jsonl), so a subsequent resume request
+   * on the same thread doesn't diverge from a session that was never
+   * actually written.
+   */
   async cancelRun(runId: string): Promise<RunObject> {
     const run = await this.store.getRun(runId);
     if (AgentRuntime.TERMINAL_RUN_STATUSES.has(run.status)) {
@@ -551,6 +704,26 @@ export class AgentRuntime {
 
     const task = this.runningTasks.get(runId);
     if (task) {
+      if (!task.committed) {
+        try {
+          await this.waitForCommitted(task, this.cancelCommitTimeoutMs);
+        } catch (err) {
+          // Commit watchdog timed out. Mark the run as failed *before*
+          // aborting so the execution path's finaliseAbortedRun sees a
+          // terminal status and skips the cancelled transition. The thread
+          // is left untouched because task.committed is still false.
+          try {
+            await this.store.updateRun(runId, rb.fail(err as Error));
+          } catch (storeErr) {
+            this.logger.error('[AgentRuntime] failed to mark run failed after cancel timeout:', storeErr);
+          }
+          task.abortController.abort();
+          await task.promise.catch(() => {
+            /* ignore */
+          });
+          throw err;
+        }
+      }
       task.abortController.abort();
       await task.promise.catch(() => {
         /* ignore */

--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -506,27 +506,37 @@ export class AgentRuntime {
   private waitForCommitted(task: RunTaskState, timeoutMs: number): Promise<void> {
     if (task.committed) return Promise.resolve();
     return new Promise<void>((resolve, reject) => {
-      const timer = globalThis.setTimeout(() => {
+      // Handlers need to reference each other (cleanup must off() all of
+      // commit / end / timer), which would force a forward reference if the
+      // arrow functions referred to each other by name. Stash them on a
+      // shared container so cleanup can read them by property access and the
+      // source order stays linear.
+      const refs: {
+        timer?: ReturnType<typeof globalThis.setTimeout>;
+        onCommit?: () => void;
+        onEnd?: () => void;
+      } = {};
+      const cleanup = (): void => {
+        if (refs.timer) clearTimeout(refs.timer);
+        if (refs.onCommit) task.emitter.off('commit', refs.onCommit);
+        if (refs.onEnd) task.emitter.off('end', refs.onEnd);
+      };
+      refs.onCommit = () => {
+        cleanup();
+        resolve();
+      };
+      refs.onEnd = () => {
+        cleanup();
+        resolve();
+      };
+      refs.timer = globalThis.setTimeout(() => {
         cleanup();
         reject(new AgentTimeoutError(
           `Timed out waiting ${timeoutMs}ms for executor session to be committed before cancel`,
         ));
       }, timeoutMs);
-      const onCommit = (): void => {
-        cleanup();
-        resolve();
-      };
-      const onEnd = (): void => {
-        cleanup();
-        resolve();
-      };
-      const cleanup = (): void => {
-        clearTimeout(timer);
-        task.emitter.off('commit', onCommit);
-        task.emitter.off('end', onEnd);
-      };
-      task.emitter.once('commit', onCommit);
-      task.emitter.once('end', onEnd);
+      task.emitter.once('commit', refs.onCommit);
+      task.emitter.once('end', refs.onEnd);
     });
   }
 

--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -86,6 +86,19 @@ export class AgentRuntime {
     RunStatus.Expired,
   ]);
 
+  // Statuses that must short-circuit the "write Completed" path in the
+  // execution loops. Covers a TOCTOU window where another actor (most
+  // notably cancelRun's commit-timeout watchdog, which writes Failed) sets
+  // a terminal state while this worker has just exited the for-await loop
+  // but hasn't yet written rb.complete(usage). Completed is intentionally
+  // excluded so the normal success path is not routed through here.
+  private static readonly POST_LOOP_TERMINAL_STATUSES = new Set<RunStatus>([
+    RunStatus.Cancelling,
+    RunStatus.Cancelled,
+    RunStatus.Failed,
+    RunStatus.Expired,
+  ]);
+
   private store: AgentStore;
   private runningTasks: Map<string, RunTaskState>;
   private runBuffers: Map<string, RunEventBuffer>;
@@ -183,6 +196,20 @@ export class AgentRuntime {
         await this.markCommittedIfNeeded(task, msg, streamMessages);
       }
 
+      // TOCTOU: another worker (e.g. cancelRun, or its commit-timeout
+      // watchdog which writes Failed) may have terminated this run while
+      // we were finishing the last iterator.next(). Respect the already-set
+      // terminal state instead of overwriting it with Completed.
+      const currentRun = await this.store.getRun(run.id);
+      if (AgentRuntime.POST_LOOP_TERMINAL_STATUSES.has(currentRun.status)) {
+        if (task.committed) {
+          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+        }
+        await this.finaliseAbortedRun(run.id);
+        const latest = await this.store.getRun(run.id);
+        return RunBuilder.fromRecord(latest).snapshot();
+      }
+
       const usage = MessageConverter.extractUsage(streamMessages);
 
       // Append input messages + stream messages to thread (excluding stream_event deltas)
@@ -258,9 +285,11 @@ export class AgentRuntime {
           await this.markCommittedIfNeeded(task, msg, streamMessages);
         }
 
-        // Check if another worker has cancelled this run before writing final state
+        // TOCTOU: respect any terminal-ish status set by another worker
+        // (cancelRun, its commit-timeout watchdog which writes Failed, or
+        // an external expiration) instead of overwriting it with Completed.
         const currentRun = await this.store.getRun(run.id);
-        if (currentRun.status === RunStatus.Cancelling || currentRun.status === RunStatus.Cancelled) {
+        if (AgentRuntime.POST_LOOP_TERMINAL_STATUSES.has(currentRun.status)) {
           return;
         }
 
@@ -424,13 +453,15 @@ export class AgentRuntime {
         await this.markCommittedIfNeeded(task, msg, streamMessages);
       }
 
-      // Check if another worker has cancelled this run before writing final state
+      // TOCTOU: respect any terminal-ish status set by another worker
+      // (cancelRun, its commit-timeout watchdog which writes Failed, or
+      // an external expiration) instead of overwriting it with Completed.
       const currentRun = await this.store.getRun(runId);
-      if (currentRun.status === RunStatus.Cancelling || currentRun.status === RunStatus.Cancelled) {
+      if (AgentRuntime.POST_LOOP_TERMINAL_STATUSES.has(currentRun.status)) {
         if (task.committed) {
           await this.persistMessagesOnAbort(threadId, input, streamMessages);
         }
-        this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
+        this.pushEvent(buffer, 'error', { message: currentRun.status, runId });
         return;
       }
 

--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -705,6 +705,11 @@ export class AgentRuntime {
     const task = this.runningTasks.get(runId);
     if (task) {
       if (!task.committed) {
+        this.logger.info(
+          '[AgentRuntime] cancelRun %s holding up to %dms for executor session to commit',
+          runId,
+          this.cancelCommitTimeoutMs,
+        );
         try {
           await this.waitForCommitted(task, this.cancelCommitTimeoutMs);
         } catch (err) {
@@ -712,6 +717,11 @@ export class AgentRuntime {
           // aborting so the execution path's finaliseAbortedRun sees a
           // terminal status and skips the cancelled transition. The thread
           // is left untouched because task.committed is still false.
+          this.logger.error(
+            '[AgentRuntime] cancelRun %s timed out after %dms waiting for executor to commit; marking run failed and leaving thread untouched',
+            runId,
+            this.cancelCommitTimeoutMs,
+          );
           try {
             await this.store.updateRun(runId, rb.fail(err as Error));
           } catch (storeErr) {

--- a/core/agent-runtime/src/RunBuilder.ts
+++ b/core/agent-runtime/src/RunBuilder.ts
@@ -89,9 +89,19 @@ export class RunBuilder {
     };
   }
 
-  /** queued/in_progress -> failed. Returns store update. */
+  /**
+   * queued/in_progress/cancelling -> failed. Returns store update.
+   *
+   * `cancelling -> failed` covers the case where AgentRuntime has initiated
+   * a cancel but the watchdog times out before the executor commits — the
+   * run is treated as a failed startup rather than a successful cancel.
+   */
   fail(error: Error): Partial<RunRecord> {
-    if (this.status !== RunStatus.InProgress && this.status !== RunStatus.Queued) {
+    if (
+      this.status !== RunStatus.InProgress &&
+      this.status !== RunStatus.Queued &&
+      this.status !== RunStatus.Cancelling
+    ) {
       throw new InvalidRunStateTransitionError(this.status, RunStatus.Failed);
     }
     this.status = RunStatus.Failed;

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -132,6 +132,9 @@ describe('test/AgentRuntime.test.ts', () => {
       executor,
       store,
       logger: {
+        info() {
+          /* noop */
+        },
         error() {
           /* noop */
         },
@@ -832,7 +835,7 @@ describe('test/AgentRuntime.test.ts', () => {
       runtime = new AgentRuntime({
         executor,
         store,
-        logger: { error() { /* noop */ } } as unknown as AgentRuntimeOptions['logger'],
+        logger: { info() { /* noop */ }, error() { /* noop */ } } as unknown as AgentRuntimeOptions['logger'],
         cancelCommitTimeoutMs: 50,
       });
 

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -13,6 +13,7 @@ import {
   AgentObjectType,
   AgentNotFoundError,
   AgentConflictError,
+  AgentTimeoutError,
 } from '@eggjs/tegg-types/agent-runtime';
 
 import { AgentRuntime } from '../src/AgentRuntime';
@@ -767,6 +768,165 @@ describe('test/AgentRuntime.test.ts', () => {
       assert.equal(run.status, RunStatus.Cancelling);
     });
 
+    it('should hold until the executor commits before aborting and persisting', async () => {
+      // Simulates the Claude Code SDK startup window: the executor emits a
+      // non-committing `system/init` right away and then a committing
+      // `assistant` message later. cancelRun is called in between and must
+      // wait for the assistant chunk before it aborts, otherwise it would
+      // persist a user message against a session file that does not yet
+      // exist on disk.
+      let resolveGate!: () => void;
+      const gate = new Promise<void>(r => { resolveGate = r; });
+      executor.execRun = async function* (_input: CreateRunInput, signal?: AbortSignal): AsyncGenerator<AgentMessage> {
+        yield { type: 'system', subtype: 'init' } as AgentMessage;
+        await gate;
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'now committed' }] } };
+        await new Promise<void>((_resolve, reject) => {
+          if (signal?.aborted) {
+            reject(new Error('aborted'));
+            return;
+          }
+          signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        });
+      };
+
+      const thread = await runtime.createThread();
+      const result = await runtime.asyncRun({
+        threadId: thread.id,
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      await waitForRunStatus(store, result.id, RunStatus.InProgress);
+
+      // Give the executor time to yield the first system message; the task
+      // must still be considered uncommitted because type === 'system'.
+      await setTimeout(30);
+
+      const cancelPromise = runtime.cancelRun(result.id);
+      let cancelResolved = false;
+      cancelPromise.then(() => { cancelResolved = true; }, () => { cancelResolved = true; });
+
+      // Hold for a bit — cancel should not resolve while we are blocked in
+      // the gate, because no committing message has been yielded yet.
+      await setTimeout(100);
+      assert.equal(cancelResolved, false, 'cancelRun must block until executor commits');
+
+      // Release the gate so the executor yields a non-system message.
+      resolveGate();
+      const cancelled = await cancelPromise;
+      assert.equal(cancelled.status, RunStatus.Cancelled);
+
+      // Thread should contain both the user input and the partial assistant
+      // reply — i.e. it is in sync with what the SDK jsonl would contain.
+      const updated = await runtime.getThread(thread.id);
+      assert.equal(updated.messages.length, 2);
+      assert.equal(updated.messages[0].type, 'user');
+      assert.equal(updated.messages[1].type, 'assistant');
+    });
+
+    it('should fail the run and leave the thread empty when cancel waits past the commit timeout', async () => {
+      // Rebuild the runtime with a short commit timeout so the watchdog
+      // fires before the blocking executor ever yields.
+      await runtime.destroy();
+      const resolveRef: { resolve?: () => void } = {};
+      executor.execRun = createBlockingExecRun(resolveRef, []);
+      runtime = new AgentRuntime({
+        executor,
+        store,
+        logger: { error() { /* noop */ } } as unknown as AgentRuntimeOptions['logger'],
+        cancelCommitTimeoutMs: 50,
+      });
+
+      const thread = await runtime.createThread();
+      const result = await runtime.asyncRun({
+        threadId: thread.id,
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      await waitForRunStatus(store, result.id, RunStatus.InProgress);
+
+      await assert.rejects(
+        () => runtime.cancelRun(result.id),
+        (err: unknown) => {
+          assert(err instanceof AgentTimeoutError, `expected AgentTimeoutError, got ${err}`);
+          return true;
+        },
+      );
+
+      const persisted = await store.getRun(result.id);
+      assert.equal(persisted.status, RunStatus.Failed);
+
+      const updated = await runtime.getThread(thread.id);
+      assert.equal(updated.messages.length, 0, 'thread must stay empty when executor never committed');
+
+      // Unblock the executor so runtime.destroy() in afterEach completes cleanly.
+      resolveRef.resolve?.();
+    });
+
+    it('should not hold cancelRun when the executor has already committed', async () => {
+      executor.execRun = createSlowExecRun([
+        { type: 'system', subtype: 'init' } as AgentMessage,
+        { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'committed' }] } },
+      ]);
+
+      const result = await runtime.asyncRun({
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      await waitForRunStatus(store, result.id, RunStatus.InProgress);
+      // Wait long enough for the assistant chunk to land and mark committed.
+      await setTimeout(50);
+
+      const start = Date.now();
+      const cancelled = await runtime.cancelRun(result.id);
+      const elapsed = Date.now() - start;
+      assert.equal(cancelled.status, RunStatus.Cancelled);
+      assert(elapsed < 1000, `cancelRun should return quickly when already committed, took ${elapsed}ms`);
+    });
+
+    it('should consult a custom isSessionCommitted hook instead of the default heuristic', async () => {
+      // The executor yields three assistant messages; the hook treats only
+      // the third as committing. cancelRun must wait for the third.
+      const decisions: Array<{ text: string; committed: boolean }> = [];
+      let resolveGate!: () => void;
+      const gate = new Promise<void>(r => { resolveGate = r; });
+      executor.execRun = async function* (_input: CreateRunInput, signal?: AbortSignal): AsyncGenerator<AgentMessage> {
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'first' }] } };
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] } };
+        await gate;
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'committed' }] } };
+        await new Promise<void>((_resolve, reject) => {
+          if (signal?.aborted) {
+            reject(new Error('aborted'));
+            return;
+          }
+          signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        });
+      };
+      executor.isSessionCommitted = (msg: AgentMessage) => {
+        const text = ((msg as { message?: { content?: Array<{ text?: string }> } }).message?.content?.[0]?.text) ?? '';
+        const committed = text === 'committed';
+        decisions.push({ text, committed });
+        return committed;
+      };
+
+      const result = await runtime.asyncRun({
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      await waitForRunStatus(store, result.id, RunStatus.InProgress);
+      // Let the first two non-committing chunks land before cancelling.
+      await setTimeout(30);
+
+      const cancelPromise = runtime.cancelRun(result.id);
+      let cancelResolved = false;
+      cancelPromise.then(() => { cancelResolved = true; }, () => { cancelResolved = true; });
+
+      await setTimeout(80);
+      assert.equal(cancelResolved, false, 'cancelRun must wait for the hook to accept a message as committed');
+
+      resolveGate();
+      const cancelled = await cancelPromise;
+      assert.equal(cancelled.status, RunStatus.Cancelled);
+      assert(decisions.some(d => d.committed), 'hook must have observed the committing chunk');
+    });
+
     it('should not overwrite terminal state when run completes during cancellation (TOCTOU)', async () => {
       const resolveRef: { resolve?: () => void } = {};
       executor.execRun = createBlockingExecRun(resolveRef, [
@@ -845,7 +1005,13 @@ describe('test/AgentRuntime.test.ts', () => {
       );
     });
 
-    it('syncRun: should persist only the user message when aborted before any chunk', async () => {
+    it('syncRun: should NOT persist the user message when aborted before the executor commits', async () => {
+      // When an external signal aborts before the executor has yielded any
+      // non-system message, the executor's underlying session (e.g. the
+      // Claude Code SDK jsonl file) was never created on disk. Persisting
+      // the user message to the thread in that state would cause the next
+      // run to diverge from a session that does not exist, so the thread
+      // must be left empty instead.
       const resolveRef: { resolve?: () => void } = {};
       executor.execRun = createBlockingExecRun(resolveRef, [
         { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'never' }] } },
@@ -864,8 +1030,7 @@ describe('test/AgentRuntime.test.ts', () => {
       await syncPromise;
 
       const updated = await runtime.getThread(thread.id);
-      assert.equal(updated.messages.length, 1);
-      assert.equal(updated.messages[0].type, 'user');
+      assert.equal(updated.messages.length, 0);
     });
 
     it('asyncRun: should persist user + partial assistant messages when aborted via cancelRun', async () => {

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -864,6 +864,66 @@ describe('test/AgentRuntime.test.ts', () => {
       resolveRef.resolve?.();
     });
 
+    it('should not overwrite watchdog-set Failed with Completed when executor finishes naturally without committing', async () => {
+      // Regression test for a TOCTOU race on the commit-timeout path:
+      //   1. cancelRun's watchdog fires at cancelCommitTimeoutMs and writes Failed.
+      //   2. The executor does not listen to the abort signal and finishes
+      //      naturally (no committing message ever yielded).
+      //   3. asyncRun's IIFE then enters its post-loop status check; without
+      //      the Failed/Expired guard it would fall through to rb.complete()
+      //      and overwrite the watchdog-set Failed with Completed.
+      await runtime.destroy();
+      let resolveGate!: () => void;
+      const gate = new Promise<void>(r => { resolveGate = r; });
+      executor = {
+        async* execRun(): AsyncGenerator<AgentMessage> {
+          yield { type: 'system', subtype: 'init' } as AgentMessage;
+          // Intentionally does NOT listen to the abort signal — simulates an
+          // executor that keeps running to natural completion after the
+          // runtime has already declared the run Failed.
+          await gate;
+        },
+      };
+      runtime = new AgentRuntime({
+        executor,
+        store,
+        logger: { info() { /* noop */ }, error() { /* noop */ } } as unknown as AgentRuntimeOptions['logger'],
+        cancelCommitTimeoutMs: 50,
+      });
+
+      const thread = await runtime.createThread();
+      const result = await runtime.asyncRun({
+        threadId: thread.id,
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      await waitForRunStatus(store, result.id, RunStatus.InProgress);
+
+      const cancelPromise = runtime.cancelRun(result.id);
+
+      // Wait well past the 50ms watchdog so Failed has definitely been
+      // written, then release the gate to let the executor finish naturally.
+      await setTimeout(150);
+      resolveGate();
+
+      await assert.rejects(
+        cancelPromise,
+        (err: unknown) => {
+          assert(err instanceof AgentTimeoutError, `expected AgentTimeoutError, got ${err}`);
+          return true;
+        },
+      );
+
+      const persisted = await store.getRun(result.id);
+      assert.equal(
+        persisted.status,
+        RunStatus.Failed,
+        'watchdog-set Failed must not be overwritten by post-loop rb.complete',
+      );
+
+      const updated = await runtime.getThread(thread.id);
+      assert.equal(updated.messages.length, 0, 'thread must stay empty when executor never committed');
+    });
+
     it('should not hold cancelRun when the executor has already committed', async () => {
       executor.execRun = createSlowExecRun([
         { type: 'system', subtype: 'init' } as AgentMessage,

--- a/core/agent-runtime/test/RunBuilder.test.ts
+++ b/core/agent-runtime/test/RunBuilder.test.ts
@@ -154,6 +154,12 @@ describe('test/RunBuilder.test.ts', () => {
       assert.equal(update.status, RunStatus.Failed);
     });
 
+    it('should allow failing from cancelling status (cancel watchdog timeout)', () => {
+      const rb = RunBuilder.create(makeRunRecord({ status: RunStatus.Cancelling }), 'thread_1');
+      const update = rb.fail(new Error('commit timeout'));
+      assert.equal(update.status, RunStatus.Failed);
+    });
+
     it('should throw for terminal status', () => {
       const rb = RunBuilder.create(makeRunRecord({ status: RunStatus.Completed }), 'thread_1');
       assert.throws(() => rb.fail(new Error('nope')), InvalidRunStateTransitionError);

--- a/core/controller-decorator/src/decorator/agent/AgentHandler.ts
+++ b/core/controller-decorator/src/decorator/agent/AgentHandler.ts
@@ -13,6 +13,18 @@ export interface AgentHandler {
   execRun(input: CreateRunInput, signal?: AbortSignal): AsyncGenerator<AgentMessage>;
   /** Create the AgentStore used to persist threads and runs. */
   createStore(): Promise<unknown>;
+  /**
+   * Optional hook to decide whether the executor's underlying session has
+   * been committed to persistent storage (for example the Claude Code SDK
+   * jsonl file on disk). The runtime calls this each time a new message is
+   * yielded from `execRun`; once it returns true, `cancelRun` is allowed to
+   * abort and persist the thread.
+   *
+   * When not implemented, the runtime uses a default heuristic: any message
+   * with `type !== 'system'` counts as committed (covers the Claude Code SDK
+   * case where `system/init` is emitted before the session is fully written).
+   */
+  isSessionCommitted?(msg: AgentMessage, history: AgentMessage[]): boolean | Promise<boolean>;
   createThread?(): Promise<ThreadObject>;
   getThread?(threadId: string): Promise<ThreadObjectWithMessages>;
   asyncRun?(input: CreateRunInput): Promise<RunObject>;

--- a/core/types/agent-runtime/errors.ts
+++ b/core/types/agent-runtime/errors.ts
@@ -37,3 +37,19 @@ export class InvalidRunStateTransitionError extends Error {
     this.name = 'InvalidRunStateTransitionError';
   }
 }
+
+/**
+ * Error thrown when cancelRun waits for the executor's session to be
+ * committed to persistent storage (e.g. Claude Code SDK jsonl on disk)
+ * but the commit never arrives within the configured timeout. The run is
+ * transitioned to `failed` rather than `cancelled` to reflect that the
+ * executor never reached a resumable state.
+ */
+export class AgentTimeoutError extends Error {
+  status = 408;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentTimeoutError';
+  }
+}


### PR DESCRIPTION
## Summary

- `cancelRun` used to abort and persist the current turn's user message the instant it was called, even when the executor's underlying session (e.g. the Claude Code SDK jsonl) had not yet been written to disk. The next resume request on the same thread would then diverge from a session that was never created and fail at executor startup.
- `cancelRun` now blocks until the executor reports a committed message (default heuristic: any `type !== 'system'`), then aborts and persists as before. If the executor never commits within `cancelCommitTimeoutMs` (default 30s), the run is marked `failed` — **not** `cancelled` — and the thread is left untouched so the next request starts with a fresh session.
- `AgentHandler` / `AgentExecutor` gain an optional `isSessionCommitted(msg, history)` hook for executors that want a stricter policy (e.g. a filesystem probe for the jsonl file) than the default heuristic.
- `RunBuilder.fail` now accepts the `cancelling → failed` transition, covering the watchdog-timeout path above.

## Behaviour changes

- `cancelRun` response time grows from ~ms to up to `cancelCommitTimeoutMs` (default 30s) in the cold-start window. Callers should be prepared for the longer HTTP hold.
- `persistMessagesOnAbort` is now gated on `task.committed` in all three execution paths (`syncRun`, `asyncRun`, `streamRun`). When the executor never committed, the thread is **not** appended with the turn's input — this is the whole point of the fix, and reverses the previous behaviour encoded by the now-updated `syncRun: should persist only the user message when aborted before any chunk` regression test.
- Timeout waiting for commit produces `AgentTimeoutError` (HTTP 408 via the `status` property) instead of a silent successful cancel.

The interface additions are fully backward compatible: `isSessionCommitted` and `cancelCommitTimeoutMs` are optional.

## Test plan

- [x] `core/agent-runtime` test suite passes (130 tests) including 4 new cases covering cancel-hold-until-committed, cancel-after-committed-is-immediate, cancel-timeout-fails-run, and custom `isSessionCommitted` hook.
- [x] `core/controller-decorator` test suite passes (74 tests).
- [x] `RunBuilder` has a new unit test for `cancelling → failed`.
- [ ] Downstream smoke test via sandbox-ai-use (planned after this lands and a canary is published).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional session-commit hook to let the runtime detect when an executor/session is persisted.
  * Runs now emit a commit event when persistence is detected; cancellation waits for commit before aborting.

* **Bug Fixes**
  * Cancellation now persists thread messages only after commit; abort-before-commit leaves thread empty.
  * Added configurable cancel timeout (cancelCommitTimeoutMs) and new AgentTimeoutError (HTTP 408) if commit times out.
  * Allow cancelling -> failed state transition without error.

* **Tests**
  * Expanded tests covering cancelRun commit behavior, timeout watchdog, and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->