### PR TITLE
feat(agent-runtime): tag stream messages with arrival timestamp

### DIFF
--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -27,6 +27,23 @@ import { MessageConverter } from './MessageConverter';
 import { RunBuilder } from './RunBuilder';
 import type { SSEWriter } from './SSEWriter';
 
+/**
+ * Tag a message with the moment we received it from the SDK stream.
+ *
+ * - Idempotent: if the SDK ever supplies its own `timestamp` (see
+ *   anthropics/claude-agent-sdk-python#258), we keep that value instead
+ *   of overwriting it. This makes the change forward-compatible with a
+ *   future upstream fix.
+ * - Format: ISO 8601 UTC string with millisecond precision, matching
+ *   Claude Code's existing jsonl transcript format.
+ */
+function tagWithTimestamp(msg: AgentMessage): AgentMessage {
+  if (typeof msg.timestamp === 'string' && msg.timestamp.length > 0) {
+    return msg;
+  }
+  return { ...msg, timestamp: new Date().toISOString() };
+}
+
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const EVENT_DIR = join(tmpdir(), 'agent-runtime-events');
 const DEFAULT_CANCEL_COMMIT_TIMEOUT_MS = 30_000;
@@ -183,7 +200,7 @@ export class AgentRuntime {
     try {
       await this.store.updateRun(run.id, rb.start());
 
-      for await (const msg of this.executor.execRun(input, abortController.signal)) {
+      for await (const rawMsg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
           if (task.committed) {
             await this.persistMessagesOnAbort(threadId, input, streamMessages);
@@ -192,6 +209,7 @@ export class AgentRuntime {
           const latest = await this.store.getRun(run.id);
           return RunBuilder.fromRecord(latest).snapshot();
         }
+        const msg = tagWithTimestamp(rawMsg);
         streamMessages.push(msg);
         await this.markCommittedIfNeeded(task, msg, streamMessages);
       }
@@ -273,7 +291,7 @@ export class AgentRuntime {
       try {
         await this.store.updateRun(run.id, rb.start());
 
-        for await (const msg of this.executor.execRun(input, abortController.signal)) {
+        for await (const rawMsg of this.executor.execRun(input, abortController.signal)) {
           if (abortController.signal.aborted) {
             if (task.committed) {
               await this.persistMessagesOnAbort(threadId, input, streamMessages);
@@ -281,6 +299,7 @@ export class AgentRuntime {
             await this.finaliseAbortedRun(run.id);
             return;
           }
+          const msg = tagWithTimestamp(rawMsg);
           streamMessages.push(msg);
           await this.markCommittedIfNeeded(task, msg, streamMessages);
         }
@@ -434,7 +453,7 @@ export class AgentRuntime {
     try {
       await this.store.updateRun(runId, rb.start());
 
-      for await (const msg of this.executor.execRun(input, abortController.signal)) {
+      for await (const rawMsg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
           if (task.committed) {
             await this.persistMessagesOnAbort(threadId, input, streamMessages);
@@ -444,6 +463,7 @@ export class AgentRuntime {
           return;
         }
 
+        const msg = tagWithTimestamp(rawMsg);
         streamMessages.push(msg);
 
         // Pass through SDK message directly as event data

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -319,6 +319,141 @@ describe('test/AgentRuntime.test.ts', () => {
     });
   });
 
+  describe('message timestamps', () => {
+    const ISO_8601_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+    it('should tag stored messages with ISO 8601 timestamps in syncRun', async () => {
+      const result = await runtime.syncRun({
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      assert.equal(result.status, RunStatus.Completed);
+
+      const thread = await store.getThread(result.threadId!, { includeAllMessages: true });
+      // input user message + executor's assistant + result
+      assert(thread.messages.length >= 2);
+      for (const msg of thread.messages) {
+        // Input messages are reconstructed by MessageConverter.toAgentMessages and
+        // do not flow through the SDK stream, so they intentionally have no
+        // timestamp. Stream-originated messages must have one.
+        if (msg.type === 'assistant' || msg.type === 'result') {
+          assert(typeof msg.timestamp === 'string',
+            `${msg.type} message missing timestamp: ${JSON.stringify(msg)}`);
+          assert(ISO_8601_RE.test(msg.timestamp!),
+            `timestamp not ISO 8601: ${msg.timestamp}`);
+        }
+      }
+    });
+
+    it('should preserve a timestamp the SDK already supplied (forward-compat)', async () => {
+      const supplied = '2026-01-01T00:00:00.000Z';
+      executor.execRun = async function* (): AsyncGenerator<AgentMessage> {
+        yield {
+          type: 'assistant',
+          // Simulate a future SDK that already includes its own timestamp
+          timestamp: supplied,
+          message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+        };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        } as SDKResultMessage;
+      };
+
+      const result = await runtime.syncRun({
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+      });
+      assert.equal(result.status, RunStatus.Completed);
+
+      const thread = await store.getThread(result.threadId!, { includeAllMessages: true });
+      const assistant = thread.messages.find(m => m.type === 'assistant');
+      assert(assistant);
+      assert.equal(assistant!.timestamp, supplied,
+        'SDK-supplied timestamp must not be overwritten by the runtime');
+
+      const resultMsg = thread.messages.find(m => m.type === 'result');
+      assert(resultMsg);
+      assert(typeof resultMsg!.timestamp === 'string',
+        'message without supplied timestamp must still get tagged');
+      assert(ISO_8601_RE.test(resultMsg!.timestamp!));
+    });
+
+    it('should reflect ordering of receive: tool_use → tool_result interval', async () => {
+      executor.execRun = async function* (): AsyncGenerator<AgentMessage> {
+        yield {
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'tu_1', name: 'echo', input: {} },
+            ],
+          },
+        };
+        // Simulate a tool execution delay so the next receive is meaningfully later
+        await setTimeout(20);
+        yield {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'ok' }],
+          },
+        };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        } as SDKResultMessage;
+      };
+
+      const result = await runtime.syncRun({
+        input: { messages: [{ role: 'user', content: 'Run echo' }] },
+      });
+      assert.equal(result.status, RunStatus.Completed);
+
+      const thread = await store.getThread(result.threadId!, { includeAllMessages: true });
+      const assistantMsg = thread.messages.find(m => m.type === 'assistant');
+      // The user(tool_result) wrapper is the second 'user' message; the first is the input.
+      const toolResultWrapper = thread.messages.filter(m => m.type === 'user').at(-1);
+      assert(assistantMsg && toolResultWrapper);
+
+      const t1 = Date.parse(assistantMsg!.timestamp!);
+      const t2 = Date.parse(toolResultWrapper!.timestamp!);
+      assert(t2 >= t1, `tool_result timestamp (${t2}) must be >= tool_use (${t1})`);
+      // ≥10ms because we slept 20ms — give some slack
+      assert(t2 - t1 >= 10,
+        `tool execution interval should reflect the >=20ms delay; got ${t2 - t1}ms`);
+    });
+
+    it('should also tag streamRun event messages', async () => {
+      executor.execRun = async function* (): AsyncGenerator<AgentMessage> {
+        yield {
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+        };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        } as SDKResultMessage;
+      };
+
+      const writer = new MockSSEWriter();
+      await runtime.streamRun({ input: { messages: [{ role: 'user', content: 'Hi' }] } }, writer);
+
+      const sdkLikeEvents = writer.events.filter(
+        e => e.event === 'assistant' || e.event === 'result',
+      );
+      assert(sdkLikeEvents.length >= 2);
+      for (const ev of sdkLikeEvents) {
+        const data = ev.data as StreamEvent;
+        const msg = data.data as AgentMessage;
+        assert(typeof msg.timestamp === 'string',
+          `streamed ${ev.event} event missing timestamp`);
+        assert(ISO_8601_RE.test(msg.timestamp!));
+      }
+    });
+  });
+
   describe('asyncRun', () => {
     it('should return queued status immediately with auto-created threadId', async () => {
       const result = await runtime.asyncRun({
@@ -490,7 +625,13 @@ describe('test/AgentRuntime.test.ts', () => {
       const assistantEvent = writer.events.find(e => e.event === 'assistant');
       assert.ok(assistantEvent);
       const streamEvent = assistantEvent.data as StreamEvent;
-      assert.deepStrictEqual(streamEvent.data, sdkMsg, 'should pass SDK message directly as data');
+      const passed = streamEvent.data as AgentMessage;
+
+      // The runtime adds an arrival `timestamp`; aside from that, the original
+      // SDK message fields must pass through untouched.
+      assert(typeof passed.timestamp === 'string', 'runtime should tag a timestamp');
+      const { timestamp: _ts, ...rest } = passed;
+      assert.deepStrictEqual(rest, sdkMsg, 'all original SDK fields must pass through');
     });
 
     it('should use "message" as default event type when type is not set', async () => {

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -630,7 +630,8 @@ describe('test/AgentRuntime.test.ts', () => {
       // The runtime adds an arrival `timestamp`; aside from that, the original
       // SDK message fields must pass through untouched.
       assert(typeof passed.timestamp === 'string', 'runtime should tag a timestamp');
-      const { timestamp: _ts, ...rest } = passed;
+      const rest: Record<string, unknown> = { ...passed };
+      delete rest.timestamp;
       assert.deepStrictEqual(rest, sdkMsg, 'all original SDK fields must pass through');
     });
 

--- a/core/types/agent-runtime/AgentMessage.ts
+++ b/core/types/agent-runtime/AgentMessage.ts
@@ -43,33 +43,58 @@ export interface InputMessage {
 // discriminate on `type` for a handful of core message kinds; everything
 // else passes through as SDKGenericMessage.
 
-export interface SDKSystemMessage {
+/**
+ * Timestamp of when this message was received from the underlying SDK
+ * stream, expressed as an ISO 8601 UTC string (e.g.
+ * `"2026-05-07T12:34:56.789Z"`). Set by the runtime at receive time so
+ * downstream consumers can derive per-step latency such as tool
+ * execution duration.
+ *
+ * **Format choice**: ISO 8601 mirrors the format Claude Code's own
+ * jsonl transcript uses today, so when the upstream SDK eventually
+ * exposes this field natively (see anthropics/claude-agent-sdk-python#258),
+ * the shape will be drop-in compatible.
+ *
+ * **Backwards compatibility**: messages persisted by older runtime
+ * versions will not have this field; consumers should treat it as
+ * optional and fall back to `Thread.createdAt` (or the surrounding
+ * `result.duration_ms`) when missing.
+ *
+ * **Forward compatibility**: if a future SDK release supplies its own
+ * `timestamp` on a message (matching this format), the runtime
+ * preserves it instead of overwriting.
+ */
+export interface AgentMessageMeta {
+  timestamp?: string;
+}
+
+export interface SDKSystemMessage extends AgentMessageMeta {
   type: 'system';
   subtype: string;
   session_id?: string;
   [key: string]: unknown;
 }
 
-export interface SDKStreamEvent {
+export interface SDKStreamEvent extends AgentMessageMeta {
   type: 'stream_event';
   event: unknown;
   session_id?: string;
   [key: string]: unknown;
 }
 
-export interface SDKUserMessage {
+export interface SDKUserMessage extends AgentMessageMeta {
   type: 'user';
   message: unknown;
   [key: string]: unknown;
 }
 
-export interface SDKAssistantMessage {
+export interface SDKAssistantMessage extends AgentMessageMeta {
   type: 'assistant';
   message: unknown;
   [key: string]: unknown;
 }
 
-export interface SDKResultMessage {
+export interface SDKResultMessage extends AgentMessageMeta {
   type: 'result';
   subtype: string;
   usage?: {
@@ -82,7 +107,7 @@ export interface SDKResultMessage {
   [key: string]: unknown;
 }
 
-export interface SDKGenericMessage {
+export interface SDKGenericMessage extends AgentMessageMeta {
   type: string;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary

Each `AgentMessage` flowing out of the runtime now carries an optional
`timestamp` (ISO 8601 UTC, ms precision) set the moment we receive
the message from the executor's SDK stream. Downstream consumers can
derive **per-step latency** from this — most importantly **tool
execution duration**:

```ts
toolDurationMs = Date.parse(toolResultMsg.timestamp)
              - Date.parse(precedingAssistantMsg.timestamp)
```

## Why

Today the only timing data we persist is the aggregated
`result.duration_ms` / `duration_api_ms`, which is **the entire run
total**. Per-step latency (LLM call, individual tool invocation) is
unrecoverable, even though the underlying Claude Code binary already
records per-message timestamps in its own jsonl transcript.

The Claude Agent SDK does not expose those timestamps to consumers
through stdio. Upstream issue tracking the gap, with maintainer ack
but no fix in 7 months:

- anthropics/claude-agent-sdk-python#258 — *Message models are missing 'timestamp' field*

This PR fills the gap at the runtime layer so all `@eggjs/agent-runtime`
consumers (including any sandbox app using it) get usable per-step
timing observability without each downstream having to reinvent the
patch.

## Open question I'd like reviewer input on (compatibility)

> If we tag manually now, will it become incompatible later when the
> upstream SDK eventually adds its own field?

Trade-off matrix considered:

| Scenario | Effect on this PR |
|---|---|
| Upstream adds `timestamp` as ISO 8601 string (matches CC's existing jsonl format — most likely) | ✅ Drop-in compatible. The runtime's idempotent guard `tagWithTimestamp` already preserves any SDK-supplied `timestamp` instead of overwriting. |
| Upstream picks a different name (e.g. `created_at`) | ✅ No conflict. We carry both; field name `timestamp` is widely used (matches CC jsonl + Anthropic API responses). |
| Upstream picks `timestamp` but as `number` (Unix ms) | ⚠️ Mismatched type. Our field is string. Runtime's preserve-rule (`typeof msg.timestamp === 'string'`) means a number-typed SDK timestamp would get overwritten by ours. Mitigation: in that hypothetical world we'd cut a follow-up release widening the preserve check to `string \| number`. |
| Upstream uses `additionalProperties: false` on the schema | ⚠️ Breaks consumers using strict schema validation. Acknowledged risk; called out in CHANGELOG. |

I rated the most likely upstream form (#1) as the design target —
hence ISO 8601 string mirroring CC's jsonl format. I'd like a sanity
check on this judgment before we ship.

## Backwards compatibility

- **Type:** new optional field, widening only. Existing consumers ignore it.
- **Runtime data:** new messages have it; old persisted threads do not. Consumers should fall back to `Thread.createdAt` when missing.
- **filterForStorage / appendMessages signatures:** unchanged.
- **Storage cost:** ~30 bytes per message; negligible.
- **Forward compatibility:** if SDK ever supplies its own `timestamp`, we preserve (don't overwrite).

## Tests

Added a new `describe('message timestamps')` block in
`test/AgentRuntime.test.ts`:

- ✅ `should tag stored messages with ISO 8601 timestamps in syncRun`
- ✅ `should preserve a timestamp the SDK already supplied (forward-compat)`
- ✅ `should reflect ordering of receive: tool_use → tool_result interval` (sleeps 20ms in the fake executor and verifies `t2 - t1 ≥ 10ms`)
- ✅ `should also tag streamRun event messages`

Updated one existing test (`streamRun > should pass through SDK
message directly as event data`) to reflect that the runtime now
adds a `timestamp` — the rest of the SDK message still passes
through unchanged.

Test results on this branch:
```
133 passing  (was 129 on master, this PR adds 4 + adapts 1)
2 failing    (pre-existing on master, unrelated to this change:
              `AgentTimeoutError is not a constructor` in cancelRun
              tests; will track separately if not already)
```

## Test plan

- [x] `npm run tsc` (core/agent-runtime) passes
- [x] `npm test` (core/agent-runtime) — 4 new tests pass; pre-existing 2 failures untouched
- [ ] Reviewer to confirm the compatibility risk analysis above is acceptable
- [ ] If accepted, follow-up: file equivalent issue at anthropics/claude-agent-sdk-typescript referencing #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent runtime messages now automatically receive ISO-8601 UTC timestamps during streaming, preserving any existing timestamps supplied by the SDK.

* **Tests**
  * Added comprehensive test coverage for message timestamp generation and preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->