### PR TITLE
chore: remove unused mcpServerMap from MCPControllerRegister

### DIFF
--- a/plugin/controller/lib/impl/mcp/MCPControllerRegister.ts
+++ b/plugin/controller/lib/impl/mcp/MCPControllerRegister.ts
@@ -93,7 +93,6 @@ export class MCPControllerRegister implements ControllerRegister {
   { res: ServerResponse; intervalId: NodeJS.Timeout }
   >();
   mcpServerHelperMap: Record<string, () => MCPServerHelper> = {};
-  mcpServerMap: Record<string, McpServer> = {};
   private controllerMeta: MCPControllerMeta;
   mcpConfig: MCPConfig;
   streamTransports: Record<string, StreamableHTTPServerTransport> = {};
@@ -481,7 +480,6 @@ export class MCPControllerRegister implements ControllerRegister {
         );
       }
       await mcpServerHelper.server.connect(transport);
-      self.mcpServerMap[id] = mcpServerHelper.server;
       if (self.mcpConfig.getSsePingEnabled(name)) {
         self.mcpServerPing(mcpServerHelper.server.server, transport.sessionId, name);
       }
@@ -497,7 +495,6 @@ export class MCPControllerRegister implements ControllerRegister {
 
   async clearSseMcpServer(transport: SSEServerTransport) {
     delete this.transports[transport.sessionId];
-    delete this.mcpServerMap[transport.sessionId];
     if (transport.sessionId && this.pingIntervals[transport.sessionId]) {
       clearInterval(this.pingIntervals[transport.sessionId]);
       delete this.pingIntervals[transport.sessionId];
@@ -685,7 +682,6 @@ export class MCPControllerRegister implements ControllerRegister {
             await server.close();
           } else if (streamTransport) {
             delete this.streamTransports[sessionId];
-            delete this.mcpServerMap[sessionId];
             if (this.pingIntervals[sessionId]) {
               clearInterval(this.pingIntervals[sessionId]);
               delete this.pingIntervals[sessionId];

--- a/plugin/controller/test/mcp/mcp.test.ts
+++ b/plugin/controller/test/mcp/mcp.test.ts
@@ -1368,7 +1368,6 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       const activeSessionId = sessionIds[sessionIds.length - 1];
       assert(register.transports[activeSessionId], 'transport should exist for session');
       assert(register.sseConnections.has(activeSessionId), 'sseConnections should have the session');
-      assert(register.mcpServerMap[activeSessionId], 'mcpServerMap should have the session');
 
       // Close the SSE transport
       await sseTransport.close();
@@ -1379,7 +1378,6 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       // Verify session is cleaned up
       assert(!register.transports[activeSessionId], 'transport should be cleaned up after close');
       assert(!register.sseConnections.has(activeSessionId), 'sseConnections should be cleaned up after close');
-      assert(!register.mcpServerMap[activeSessionId], 'mcpServerMap should be cleaned up after close');
     });
 
     it('should return 400 when checkAndRunProxy returns false for non-existent session', async () => {

--- a/plugin/mcp-proxy/index.ts
+++ b/plugin/mcp-proxy/index.ts
@@ -115,10 +115,9 @@ export const MCPProxyHook: MCPControllerHook = {
       self.app.mcpProxy.unregisterClient(id);
     });
   },
-  async onStreamSessionInitialized(_ctx, transport, server, self) {
+  async onStreamSessionInitialized(_ctx, transport, _server, self) {
     const sessionId = transport.sessionId!;
     self.streamTransports[sessionId] = transport;
-    self.mcpServerMap[sessionId] = server;
     self.app.mcpProxy.setProxyHandler(MCPProtocols.STREAM, async (req: http.IncomingMessage, res: http.ServerResponse) => {
       let mw = self.app.middleware.teggCtxLifecycleMiddleware();
       if (self.globalMiddlewares) {
@@ -183,7 +182,6 @@ export const MCPProxyHook: MCPControllerHook = {
       const sid = transport.sessionId;
       if (sid && self.streamTransports[sid]) {
         delete self.streamTransports[sid];
-        delete self.mcpServerMap[sid];
       }
       await self.app.mcpProxy.unregisterClient(sid!);
     };


### PR DESCRIPTION
The mcpServerMap was only ever written and deleted, never read by any production code. The only readers were two test assertions that were verifying the bookkeeping itself.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal session management and cleanup logic for stream handling.

This release includes internal code improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->