### PR TITLE
feat(agent-runtime): per-thread creation-time index

### DIFF
--- a/core/agent-runtime/package.json
+++ b/core/agent-runtime/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@eggjs/tegg-types": "^3.78.17",
-    "dayjs": "^1.11.19",
     "egg-logger": "^3.0.1",
     "oss-client": "^2.5.1"
   },

--- a/core/agent-runtime/package.json
+++ b/core/agent-runtime/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@eggjs/tegg-types": "^3.78.17",
+    "dayjs": "^1.11.19",
     "egg-logger": "^3.0.1",
     "oss-client": "^2.5.1"
   },

--- a/core/agent-runtime/src/AgentStoreUtils.ts
+++ b/core/agent-runtime/src/AgentStoreUtils.ts
@@ -1,5 +1,15 @@
 import crypto from 'node:crypto';
 
+import dayjs from 'dayjs';
+import dayjsTimezone from 'dayjs/plugin/timezone';
+import dayjsUtc from 'dayjs/plugin/utc';
+
+// Register the dayjs UTC + IANA-timezone plugins exactly once at module
+// load. `dayjs.extend` is idempotent so re-registering the same plugin
+// in another module that also imports the timezone plugin is a no-op.
+dayjs.extend(dayjsUtc);
+dayjs.extend(dayjsTimezone);
+
 export function nowUnix(): number {
   return Math.floor(Date.now() / 1000);
 }
@@ -31,15 +41,17 @@ export const TS_MAX_MS = 9_999_999_999_999;
 const REV_MS_WIDTH = String(TS_MAX_MS).length;
 
 /**
- * Encode a millisecond timestamp as a fixed-width, zero-padded decimal string
- * representing `TS_MAX_MS - ms`. Because the width is constant, ASCII
- * (= lexicographic) order on the resulting strings is identical to the
- * numeric order of the complement, and therefore the *reverse* of the
- * original time order. A directory of keys carrying this suffix lists
- * newest-first when an object store returns entries in dictionary order.
+ * Encode a millisecond timestamp as a fixed-width, zero-padded decimal
+ * string representing `TS_MAX_MS - ms`. Because the width is constant,
+ * ASCII (= lexicographic) order on the resulting strings is identical
+ * to the numeric order of the complement, and therefore the *reverse* of
+ * the original time order. A directory of keys carrying this suffix
+ * lists newest-first when an object store returns entries in dictionary
+ * order.
  *
  * Throws `RangeError` if `ms` is not an integer in `[0, TS_MAX_MS]`,
- * which guards against floats, negatives, and the post-9999-year overflow.
+ * which guards against floats, negatives, and the post-year-2286
+ * overflow.
  */
 export function reverseMs(ms: number): string {
   if (!Number.isInteger(ms) || ms < 0 || ms > TS_MAX_MS) {
@@ -49,48 +61,107 @@ export function reverseMs(ms: number): string {
 }
 
 /**
- * Inverse of `reverseMs`. Parses a 13-digit complement string back into the
- * original millisecond timestamp.
- *
- * Useful in downstream analytics scripts that walk the time-index prefix
- * and want to recover the creation timestamp without GETting each object's
- * body.
- *
- * Throws `TypeError` when the input cannot be parsed as a finite decimal
- * integer.
+ * Inverse of `reverseMs`: returns the Unix-millisecond timestamp whose
+ * `reverseMs` output is the given 13-character zero-padded decimal
+ * string. The input contract — exactly thirteen ASCII digits, the
+ * literal output of `reverseMs` — is the caller's responsibility;
+ * behavior is undefined for any other input, since the standard
+ * `Number.parseInt(s, 10)` "longest valid decimal prefix" semantics
+ * silently drop a trailing non-digit suffix and consume a leading sign
+ * character. In-tegg the only producer is `OSSAgentStore`'s time-index
+ * key shape, which emits the correct form by construction; external
+ * backfill or analytics scripts that compose the input from an OSS key
+ * suffix are responsible for their own slicing.
  */
 export function decodeReverseMs(revMsString: string): number {
-  const n = Number.parseInt(revMsString, 10);
-  if (!Number.isFinite(n)) {
-    throw new TypeError(`decodeReverseMs: not a decimal integer: ${JSON.stringify(revMsString)}`);
-  }
-  return TS_MAX_MS - n;
+  return TS_MAX_MS - Number.parseInt(revMsString, 10);
 }
 
 /**
- * Format an absolute millisecond timestamp as a `YYYY-MM-DD` calendar-day
- * string in the supplied IANA timezone.
+ * Format an absolute Unix-millisecond timestamp as the `YYYY-MM-DD`
+ * date-bucket directory name used by the OSS time-index keyspace.
  *
- * The `'UTC'` branch (case-insensitive, the default) uses the engine's
- * built-in `Date.prototype.toISOString()` and is allocation-cheap. Any other
- * value is passed through `Intl.DateTimeFormat('en-CA', { timeZone })`,
- * whose `en-CA` locale already produces the `YYYY-MM-DD` form expected by
- * data-warehouse date-partition conventions.
+ * The UTC case (the default, accepting the case-insensitive `'utc'` and
+ * `'UTC'` aliases) is short-circuited through the ECMA-262
+ * `Date.prototype.toISOString().slice(0, 10)` standard-library call.
+ * That produces the four-digit Gregorian year, two-digit month, and
+ * two-digit day separated by literal hyphens in the UTC timezone, with
+ * ASCII decimal digits, deterministically across every JavaScript
+ * runtime regardless of `Intl` library availability or CLDR data
+ * version. Notably the short-circuit works on small-ICU Node builds
+ * and on JavaScript runtimes that ship without an `Intl` namespace,
+ * which the more-general `Intl.DateTimeFormat`-based path does not.
  *
- * UTC is the default so that workers across regions partition the same
- * absolute instant into the same date directory. Pass an explicit zone
- * (e.g. `'Asia/Shanghai'`) when the analytics calendar follows a specific
- * local timezone.
+ * Any other timezone name is routed through dayjs's IANA-timezone
+ * plugin. The chain `dayjs.tz(ms, timezone).format('YYYY-MM-DD')` does
+ * the Unix-instant-to-wall-clock-fields conversion via the engine's
+ * IANA tzdata (which dayjs internally reaches through
+ * `Intl.DateTimeFormat`'s `timeZone` option, the standard ECMA-402
+ * mechanism for accessing the host's timezone database) and then
+ * substitutes the year/month/day into the literal `'YYYY-MM-DD'` token
+ * template. The template is dayjs's own — not a locale's CLDR
+ * short-date pattern, the way `Intl.DateTimeFormat({ year, month,
+ * day }).format(date)` would be — so the output's character
+ * composition is invariant across the locale data that a particular
+ * runtime ships, where the previous implementation's reliance on the
+ * `en-CA` locale's default ISO-order pattern was an empirical-fact-
+ * about-Node's-CLDR rather than an ECMA-402 contractual guarantee.
+ * The timezone-to-wall-clock half of the conversion still uses the
+ * host's tzdata, which is the standard ICU bundle that Node's official
+ * full-ICU builds ship and is the same data the prior implementation
+ * relied on.
+ *
+ * Unknown IANA timezone names produce a `RangeError`. The underlying
+ * `Intl.DateTimeFormat` constructor inside dayjs's timezone plugin
+ * already throws a `RangeError: Invalid time zone specified: <name>`
+ * for an unknown zone; the additional `dayjsObj.isValid()` check is
+ * defense-in-depth coverage for any future dayjs version that catches
+ * the Intl exception and returns an "invalid" sentinel dayjs object
+ * instead of propagating it.
+ *
+ * The input `ms` must be a finite, nonnegative integer. The pre-amend
+ * implementation silently passed a `NaN` or `Infinity` input through
+ * to either `Date.prototype.toISOString` (which throws an opaque
+ * stdlib `RangeError: Invalid time value` without naming the offending
+ * function) or `Intl.DateTimeFormat.format(new Date(NaN))` (which
+ * returns the literal string `"Invalid Date"` and would leak that
+ * string into the OSS key path as a directory name). Both edge cases
+ * are now rejected at the function boundary with a domain-aware error
+ * message.
+ *
+ * The signed-zero edge case (the IEEE-754 distinction between `+0`
+ * and `-0`, where `Object.is(-0, 0)` is `false` but `-0 < 0` is also
+ * `false` and `Number.isInteger(-0)` is `true`) is intentionally
+ * accepted: both signed zeros refer to the Unix-epoch instant
+ * `1970-01-01T00:00:00.000Z` and the function returns the same
+ * `'1970-01-01'` bucket for either input. This matches the standard
+ * JavaScript convention of treating the two signed zeros as the same
+ * mathematical value, which `Date(0)` and `Date(-0)` themselves
+ * follow.
+ *
+ * Defaults to `'UTC'` so that workers in physically different regions
+ * agree on the day-boundary partition for a given absolute instant.
+ * Pass an IANA name such as `'Asia/Shanghai'` or
+ * `'America/Los_Angeles'` to follow a specific local calendar.
  */
 export function dateBucket(ms: number, timezone = 'UTC'): string {
-  if (timezone.toUpperCase() === 'UTC') {
+  if (!Number.isInteger(ms) || ms < 0) {
+    throw new RangeError(
+      `dateBucket: ms must be a nonnegative integer Unix-millisecond timestamp, got ${ms}`,
+    );
+  }
+  // Case-insensitive UTC short-circuit. The length-3 prefix check is a
+  // micro-optimisation that avoids the `.toUpperCase` allocation on the
+  // common non-UTC names which are all longer than three characters
+  // (e.g. `'Asia/Shanghai'` is 13, `'America/Los_Angeles'` is 19).
+  if (timezone.length === 3 && timezone.toUpperCase() === 'UTC') {
     return new Date(ms).toISOString().slice(0, 10);
   }
-  const fmt = new Intl.DateTimeFormat('en-CA', {
-    timeZone: timezone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  return fmt.format(new Date(ms));
+  const d = dayjs.tz(ms, timezone);
+  if (!d.isValid()) {
+    throw new RangeError(
+      `dateBucket: dayjs returned an invalid date for timezone ${JSON.stringify(timezone)} and ms=${ms}; the timezone name is most likely not a recognised IANA zone in the host's tzdata`,
+    );
+  }
+  return d.format('YYYY-MM-DD');
 }

--- a/core/agent-runtime/src/AgentStoreUtils.ts
+++ b/core/agent-runtime/src/AgentStoreUtils.ts
@@ -35,13 +35,6 @@ export function reverseMs(ms: number): string {
 }
 
 /**
- * Decode a 13-digit `reverseMs` string back to Unix milliseconds.
- */
-export function decodeReverseMs(revMsString: string): number {
-  return TS_MAX_MS - Number.parseInt(revMsString, 10);
-}
-
-/**
  * Format a Unix-millisecond timestamp as a UTC `YYYY-MM-DD` bucket.
  */
 export function dateBucket(ms: number): string {

--- a/core/agent-runtime/src/AgentStoreUtils.ts
+++ b/core/agent-runtime/src/AgentStoreUtils.ts
@@ -1,15 +1,5 @@
 import crypto from 'node:crypto';
 
-import dayjs from 'dayjs';
-import dayjsTimezone from 'dayjs/plugin/timezone';
-import dayjsUtc from 'dayjs/plugin/utc';
-
-// Register the dayjs UTC + IANA-timezone plugins exactly once at module
-// load. `dayjs.extend` is idempotent so re-registering the same plugin
-// in another module that also imports the timezone plugin is a no-op.
-dayjs.extend(dayjsUtc);
-dayjs.extend(dayjsTimezone);
-
 export function nowUnix(): number {
   return Math.floor(Date.now() / 1000);
 }
@@ -27,31 +17,15 @@ export function newRunId(): string {
 }
 
 /**
- * Arithmetic upper bound for a 13-digit Unix millisecond timestamp,
- * corresponding to UTC 2286-11-20T17:46:39.999Z — well past any realistic
- * deployment lifetime.
- *
- * Used as the operand of the "time complement" encoding in `reverseMs`,
- * so a key whose numeric suffix is `TS_MAX_MS - ms` sorts newest-first
- * under an ASC-only ListObjects (the OSS / S3 protocol family exposes no
- * native reverse-order list).
+ * Upper bound for 13-digit millisecond timestamps. The time complement
+ * `TS_MAX_MS - ms` sorts newest-first in ascending key order.
  */
 export const TS_MAX_MS = 9_999_999_999_999;
 
 const REV_MS_WIDTH = String(TS_MAX_MS).length;
 
 /**
- * Encode a millisecond timestamp as a fixed-width, zero-padded decimal
- * string representing `TS_MAX_MS - ms`. Because the width is constant,
- * ASCII (= lexicographic) order on the resulting strings is identical
- * to the numeric order of the complement, and therefore the *reverse* of
- * the original time order. A directory of keys carrying this suffix
- * lists newest-first when an object store returns entries in dictionary
- * order.
- *
- * Throws `RangeError` if `ms` is not an integer in `[0, TS_MAX_MS]`,
- * which guards against floats, negatives, and the post-year-2286
- * overflow.
+ * Encode a millisecond timestamp so ascending key order is newest-first.
  */
 export function reverseMs(ms: number): string {
   if (!Number.isInteger(ms) || ms < 0 || ms > TS_MAX_MS) {
@@ -61,107 +35,20 @@ export function reverseMs(ms: number): string {
 }
 
 /**
- * Inverse of `reverseMs`: returns the Unix-millisecond timestamp whose
- * `reverseMs` output is the given 13-character zero-padded decimal
- * string. The input contract — exactly thirteen ASCII digits, the
- * literal output of `reverseMs` — is the caller's responsibility;
- * behavior is undefined for any other input, since the standard
- * `Number.parseInt(s, 10)` "longest valid decimal prefix" semantics
- * silently drop a trailing non-digit suffix and consume a leading sign
- * character. In-tegg the only producer is `OSSAgentStore`'s time-index
- * key shape, which emits the correct form by construction; external
- * backfill or analytics scripts that compose the input from an OSS key
- * suffix are responsible for their own slicing.
+ * Decode a 13-digit `reverseMs` string back to Unix milliseconds.
  */
 export function decodeReverseMs(revMsString: string): number {
   return TS_MAX_MS - Number.parseInt(revMsString, 10);
 }
 
 /**
- * Format an absolute Unix-millisecond timestamp as the `YYYY-MM-DD`
- * date-bucket directory name used by the OSS time-index keyspace.
- *
- * The UTC case (the default, accepting the case-insensitive `'utc'` and
- * `'UTC'` aliases) is short-circuited through the ECMA-262
- * `Date.prototype.toISOString().slice(0, 10)` standard-library call.
- * That produces the four-digit Gregorian year, two-digit month, and
- * two-digit day separated by literal hyphens in the UTC timezone, with
- * ASCII decimal digits, deterministically across every JavaScript
- * runtime regardless of `Intl` library availability or CLDR data
- * version. Notably the short-circuit works on small-ICU Node builds
- * and on JavaScript runtimes that ship without an `Intl` namespace,
- * which the more-general `Intl.DateTimeFormat`-based path does not.
- *
- * Any other timezone name is routed through dayjs's IANA-timezone
- * plugin. The chain `dayjs.tz(ms, timezone).format('YYYY-MM-DD')` does
- * the Unix-instant-to-wall-clock-fields conversion via the engine's
- * IANA tzdata (which dayjs internally reaches through
- * `Intl.DateTimeFormat`'s `timeZone` option, the standard ECMA-402
- * mechanism for accessing the host's timezone database) and then
- * substitutes the year/month/day into the literal `'YYYY-MM-DD'` token
- * template. The template is dayjs's own — not a locale's CLDR
- * short-date pattern, the way `Intl.DateTimeFormat({ year, month,
- * day }).format(date)` would be — so the output's character
- * composition is invariant across the locale data that a particular
- * runtime ships, where the previous implementation's reliance on the
- * `en-CA` locale's default ISO-order pattern was an empirical-fact-
- * about-Node's-CLDR rather than an ECMA-402 contractual guarantee.
- * The timezone-to-wall-clock half of the conversion still uses the
- * host's tzdata, which is the standard ICU bundle that Node's official
- * full-ICU builds ship and is the same data the prior implementation
- * relied on.
- *
- * Unknown IANA timezone names produce a `RangeError`. The underlying
- * `Intl.DateTimeFormat` constructor inside dayjs's timezone plugin
- * already throws a `RangeError: Invalid time zone specified: <name>`
- * for an unknown zone; the additional `dayjsObj.isValid()` check is
- * defense-in-depth coverage for any future dayjs version that catches
- * the Intl exception and returns an "invalid" sentinel dayjs object
- * instead of propagating it.
- *
- * The input `ms` must be a finite, nonnegative integer. The pre-amend
- * implementation silently passed a `NaN` or `Infinity` input through
- * to either `Date.prototype.toISOString` (which throws an opaque
- * stdlib `RangeError: Invalid time value` without naming the offending
- * function) or `Intl.DateTimeFormat.format(new Date(NaN))` (which
- * returns the literal string `"Invalid Date"` and would leak that
- * string into the OSS key path as a directory name). Both edge cases
- * are now rejected at the function boundary with a domain-aware error
- * message.
- *
- * The signed-zero edge case (the IEEE-754 distinction between `+0`
- * and `-0`, where `Object.is(-0, 0)` is `false` but `-0 < 0` is also
- * `false` and `Number.isInteger(-0)` is `true`) is intentionally
- * accepted: both signed zeros refer to the Unix-epoch instant
- * `1970-01-01T00:00:00.000Z` and the function returns the same
- * `'1970-01-01'` bucket for either input. This matches the standard
- * JavaScript convention of treating the two signed zeros as the same
- * mathematical value, which `Date(0)` and `Date(-0)` themselves
- * follow.
- *
- * Defaults to `'UTC'` so that workers in physically different regions
- * agree on the day-boundary partition for a given absolute instant.
- * Pass an IANA name such as `'Asia/Shanghai'` or
- * `'America/Los_Angeles'` to follow a specific local calendar.
+ * Format a Unix-millisecond timestamp as a UTC `YYYY-MM-DD` bucket.
  */
-export function dateBucket(ms: number, timezone = 'UTC'): string {
+export function dateBucket(ms: number): string {
   if (!Number.isInteger(ms) || ms < 0) {
     throw new RangeError(
       `dateBucket: ms must be a nonnegative integer Unix-millisecond timestamp, got ${ms}`,
     );
   }
-  // Case-insensitive UTC short-circuit. The length-3 prefix check is a
-  // micro-optimisation that avoids the `.toUpperCase` allocation on the
-  // common non-UTC names which are all longer than three characters
-  // (e.g. `'Asia/Shanghai'` is 13, `'America/Los_Angeles'` is 19).
-  if (timezone.length === 3 && timezone.toUpperCase() === 'UTC') {
-    return new Date(ms).toISOString().slice(0, 10);
-  }
-  const d = dayjs.tz(ms, timezone);
-  if (!d.isValid()) {
-    throw new RangeError(
-      `dateBucket: dayjs returned an invalid date for timezone ${JSON.stringify(timezone)} and ms=${ms}; the timezone name is most likely not a recognised IANA zone in the host's tzdata`,
-    );
-  }
-  return d.format('YYYY-MM-DD');
+  return new Date(ms).toISOString().slice(0, 10);
 }

--- a/core/agent-runtime/src/AgentStoreUtils.ts
+++ b/core/agent-runtime/src/AgentStoreUtils.ts
@@ -15,3 +15,82 @@ export function newThreadId(): string {
 export function newRunId(): string {
   return `run_${crypto.randomUUID()}`;
 }
+
+/**
+ * Arithmetic upper bound for a 13-digit Unix millisecond timestamp,
+ * corresponding to UTC 2286-11-20T17:46:39.999Z — well past any realistic
+ * deployment lifetime.
+ *
+ * Used as the operand of the "time complement" encoding in `reverseMs`,
+ * so a key whose numeric suffix is `TS_MAX_MS - ms` sorts newest-first
+ * under an ASC-only ListObjects (the OSS / S3 protocol family exposes no
+ * native reverse-order list).
+ */
+export const TS_MAX_MS = 9_999_999_999_999;
+
+const REV_MS_WIDTH = String(TS_MAX_MS).length;
+
+/**
+ * Encode a millisecond timestamp as a fixed-width, zero-padded decimal string
+ * representing `TS_MAX_MS - ms`. Because the width is constant, ASCII
+ * (= lexicographic) order on the resulting strings is identical to the
+ * numeric order of the complement, and therefore the *reverse* of the
+ * original time order. A directory of keys carrying this suffix lists
+ * newest-first when an object store returns entries in dictionary order.
+ *
+ * Throws `RangeError` if `ms` is not an integer in `[0, TS_MAX_MS]`,
+ * which guards against floats, negatives, and the post-9999-year overflow.
+ */
+export function reverseMs(ms: number): string {
+  if (!Number.isInteger(ms) || ms < 0 || ms > TS_MAX_MS) {
+    throw new RangeError(`reverseMs: ms must be an integer in [0, ${TS_MAX_MS}], got ${ms}`);
+  }
+  return String(TS_MAX_MS - ms).padStart(REV_MS_WIDTH, '0');
+}
+
+/**
+ * Inverse of `reverseMs`. Parses a 13-digit complement string back into the
+ * original millisecond timestamp.
+ *
+ * Useful in downstream analytics scripts that walk the time-index prefix
+ * and want to recover the creation timestamp without GETting each object's
+ * body.
+ *
+ * Throws `TypeError` when the input cannot be parsed as a finite decimal
+ * integer.
+ */
+export function decodeReverseMs(revMsString: string): number {
+  const n = Number.parseInt(revMsString, 10);
+  if (!Number.isFinite(n)) {
+    throw new TypeError(`decodeReverseMs: not a decimal integer: ${JSON.stringify(revMsString)}`);
+  }
+  return TS_MAX_MS - n;
+}
+
+/**
+ * Format an absolute millisecond timestamp as a `YYYY-MM-DD` calendar-day
+ * string in the supplied IANA timezone.
+ *
+ * The `'UTC'` branch (case-insensitive, the default) uses the engine's
+ * built-in `Date.prototype.toISOString()` and is allocation-cheap. Any other
+ * value is passed through `Intl.DateTimeFormat('en-CA', { timeZone })`,
+ * whose `en-CA` locale already produces the `YYYY-MM-DD` form expected by
+ * data-warehouse date-partition conventions.
+ *
+ * UTC is the default so that workers across regions partition the same
+ * absolute instant into the same date directory. Pass an explicit zone
+ * (e.g. `'Asia/Shanghai'`) when the analytics calendar follows a specific
+ * local timezone.
+ */
+export function dateBucket(ms: number, timezone = 'UTC'): string {
+  if (timezone.toUpperCase() === 'UTC') {
+    return new Date(ms).toISOString().slice(0, 10);
+  }
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return fmt.format(new Date(ms));
+}

--- a/core/agent-runtime/src/OSSAgentStore.ts
+++ b/core/agent-runtime/src/OSSAgentStore.ts
@@ -9,11 +9,35 @@ import type {
   ObjectStorageClient } from '@eggjs/tegg-types/agent-runtime';
 import { AgentObjectType, RunStatus, AgentNotFoundError } from '@eggjs/tegg-types/agent-runtime';
 
-import { nowUnix, newThreadId, newRunId } from './AgentStoreUtils';
+import { dateBucket, newRunId, newThreadId, nowUnix, reverseMs } from './AgentStoreUtils';
+
+/**
+ * Minimal structural type for the warn-logging channel used when a
+ * background thread-time-index write fails. Both `egg-logger`'s `EggLogger`
+ * and the global `console` satisfy this shape, so applications can pass
+ * `app.logger` directly without an explicit import.
+ */
+export interface OSSAgentStoreWarnLogger {
+  warn(message: string, ...args: unknown[]): void;
+}
 
 export interface OSSAgentStoreOptions {
   client: ObjectStorageClient;
   prefix?: string;
+  /**
+   * Sink for warn messages emitted when the background time-index PUT fails.
+   * Defaults to a wrapper around `console.warn`. Failures never surface to
+   * the `createThread` caller — they are observed exclusively via this logger.
+   */
+  logger?: OSSAgentStoreWarnLogger;
+  /**
+   * IANA timezone name (or the literal `'UTC'`) used to compute the
+   * `YYYY-MM-DD` date-bucket directory of the time index. Defaults to
+   * `'UTC'` so that workers in different physical regions agree on a single
+   * partition for a given absolute instant. Set to e.g. `'Asia/Shanghai'`
+   * when the analytics calendar follows a specific local timezone.
+   */
+  dateTimezone?: string;
 }
 
 /**
@@ -28,19 +52,48 @@ type ThreadMetadata = Omit<ThreadRecord, 'messages'>;
  * ## Storage layout
  *
  * ```
- * {prefix}threads/{id}/meta.json      — Thread metadata (JSON)
- * {prefix}threads/{id}/messages.jsonl  — Messages (JSONL, one AgentMessage per line)
- * {prefix}runs/{id}.json              — Run record (JSON)
+ * {prefix}threads/{id}/meta.json                                  — Thread metadata (JSON, source of truth)
+ * {prefix}threads/{id}/messages.jsonl                             — Messages (JSONL, one AgentMessage per line)
+ * {prefix}runs/{id}.json                                          — Run record (JSON)
+ * {prefix}index/threads-by-date/{YYYY-MM-DD}/{revMs13}_{threadId} — Time index sidecar, body JSON
  * ```
+ *
+ * The time-index sidecar is a write-only, analytics-facing artifact: it is
+ * created best-effort inside `createThread`, never read by `getThread`, and
+ * never mutated by `appendMessages` / `createRun` / `updateRun`. Its
+ * filename's `revMs13` segment is the decimal complement of the
+ * millisecond-precision creation timestamp (see `reverseMs` in
+ * `AgentStoreUtils`), which makes the natural ASC-by-key dictionary order
+ * of a date directory equivalent to time-DESC order — a workaround for the
+ * fact that the OSS / S3 ListObjects API has no reverse-order option. The
+ * body is a compact JSON document carrying `{ threadId, createdAt, metadata }`
+ * so that consumers reading only the index never need to GET `meta.json`.
+ *
+ * The index PUT is fire-and-forget: it runs on a background promise tracked
+ * in `pendingIndexWrites`, contributes zero latency to `createThread`'s
+ * happy path, and a failure produces a single `warn` line via the injected
+ * `logger` instead of propagating. Call `awaitPendingWrites()` (or
+ * `destroy()`, which calls it internally) when graceful shutdown must wait
+ * for in-flight index writes to settle.
  */
 export class OSSAgentStore implements AgentStore {
   private readonly client: ObjectStorageClient;
   private readonly prefix: string;
+  private readonly logger: OSSAgentStoreWarnLogger;
+  private readonly dateTimezone: string;
+  /**
+   * Background index writes that have not yet settled. Each promise removes
+   * itself from the set on resolution or rejection, so the set never grows
+   * unboundedly. `awaitPendingWrites()` and `destroy()` drain it.
+   */
+  private readonly pendingIndexWrites = new Set<Promise<void>>();
 
   constructor(options: OSSAgentStoreOptions) {
     this.client = options.client;
     const raw = options.prefix ?? '';
     this.prefix = raw && !raw.endsWith('/') ? raw + '/' : raw;
+    this.logger = options.logger ?? { warn: (message, ...args) => console.warn(message, ...args) };
+    this.dateTimezone = options.dateTimezone ?? 'UTC';
   }
 
   private threadMetaKey(threadId: string): string {
@@ -55,23 +108,91 @@ export class OSSAgentStore implements AgentStore {
     return `${this.prefix}runs/${runId}.json`;
   }
 
+  /**
+   * Compose the time-index sidecar key for a thread created at `nowMs`.
+   * `dateBucket` resolves the timezone, `reverseMs` produces the complement
+   * suffix; the threadId is appended verbatim so that consumers can read it
+   * from the key without GETting the body.
+   */
+  private threadTimeIndexKey(nowMs: number, threadId: string): string {
+    const date = dateBucket(nowMs, this.dateTimezone);
+    const rev = reverseMs(nowMs);
+    return `${this.prefix}index/threads-by-date/${date}/${rev}_${threadId}`;
+  }
+
   async init(): Promise<void> {
     await this.client.init?.();
   }
 
   async destroy(): Promise<void> {
+    // Drain pending background index writes before tearing down the
+    // underlying client. `Promise.allSettled` swallows individual failures
+    // (which are already surfaced via the logger), so destroy() itself
+    // never rejects because of an index miss.
+    await this.awaitPendingWrites();
     await this.client.destroy?.();
+  }
+
+  /**
+   * Wait for every in-flight background time-index write to settle (either
+   * resolve or reject). Used internally by `destroy()` to keep graceful
+   * shutdown from dropping writes, and exposed publicly for tests and
+   * external callers that need an explicit drain point.
+   *
+   * Never rejects — individual write failures have already been turned into
+   * `warn` log entries by the catch handler installed in `createThread`.
+   */
+  async awaitPendingWrites(): Promise<void> {
+    if (this.pendingIndexWrites.size === 0) return;
+    await Promise.allSettled([ ...this.pendingIndexWrites ]);
   }
 
   async createThread(metadata?: Record<string, unknown>): Promise<ThreadRecord> {
     const threadId = newThreadId();
+    // Take the wall-clock once so the seconds value written into `meta.createdAt`
+    // and the millisecond value encoded into the index key derive from the same
+    // physical instant. Two separate `Date.now()` reads could disagree across
+    // a millisecond boundary and, near midnight, even across the date bucket.
+    const nowMs = Date.now();
+    const createdAt = Math.floor(nowMs / 1000);
     const meta: ThreadMetadata = {
       id: threadId,
       object: AgentObjectType.Thread,
       metadata: metadata ?? {},
-      createdAt: nowUnix(),
+      createdAt,
     };
+    // 1) Main path. Failure surfaces to the caller exactly as before.
     await this.client.put(this.threadMetaKey(threadId), JSON.stringify(meta));
+
+    // 2) Time-index sidecar. Fire-and-forget: the promise is tracked in
+    //    `pendingIndexWrites` so graceful shutdown can drain it, but
+    //    `createThread` does not await it and a rejection produces a
+    //    warn log rather than propagating. The two-arg `.then(success,
+    //    failure)` form serves both as a handler and as the standard
+    //    means of silencing the unhandled-rejection warning.
+    const indexKey = this.threadTimeIndexKey(nowMs, threadId);
+    const indexBody = JSON.stringify({
+      threadId,
+      createdAt,
+      metadata: meta.metadata,
+    });
+    const tracked: Promise<void> = this.client.put(indexKey, indexBody).then(
+      () => {
+        this.pendingIndexWrites.delete(tracked);
+      },
+      (err: unknown) => {
+        this.pendingIndexWrites.delete(tracked);
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(
+          '[OSSAgentStore] failed to write thread time index threadId=%s key=%s err=%s',
+          threadId,
+          indexKey,
+          message,
+        );
+      },
+    );
+    this.pendingIndexWrites.add(tracked);
+
     return { ...meta, messages: [] };
   }
 

--- a/core/agent-runtime/src/OSSAgentStore.ts
+++ b/core/agent-runtime/src/OSSAgentStore.ts
@@ -12,24 +12,8 @@ import { AgentObjectType, RunStatus, AgentNotFoundError } from '@eggjs/tegg-type
 import { dateBucket, newRunId, newThreadId, nowUnix, reverseMs } from './AgentStoreUtils';
 
 /**
- * Minimal structural type for the warn-logging channel used when a
- * background thread-time-index write fails. Both `egg-logger`'s
- * `EggLogger` and the global `console` satisfy this shape, so
- * applications can pass `app.logger` directly without importing any
- * egg-specific types here.
- *
- * The implementation is expected to follow Node's `util.format`
- * conventions: leading args fill the `%s` / `%d` / `%j` / `%o` / `%O`
- * placeholders in the format string, and any trailing args beyond the
- * placeholder count are appended to the rendered output via
- * `util.inspect`. For an `Error` instance in a trailing slot
- * `util.inspect` includes the stack trace and any `Error.cause` chain,
- * which is the property the warn-on-index-failure call site relies on
- * for observability. Both `console.warn` and `EggLogger.warn` honor
- * the `util.format` convention; a custom structured logger that does
- * not implement `%s`-interpolation may render the format string and
- * the args differently, which is a known idiomatic-difference between
- * the printf-style and the structured-log conventions.
+ * Warn logger used when a background thread-time-index write fails.
+ * `console` and `egg-logger` both satisfy this shape.
  */
 export interface OSSAgentStoreWarnLogger {
   warn(message: string, ...args: unknown[]): void;
@@ -39,22 +23,10 @@ export interface OSSAgentStoreOptions {
   client: ObjectStorageClient;
   prefix?: string;
   /**
-   * Sink for warn messages emitted when the background time-index PUT
-   * fails. Defaults to a thin wrapper around `console.warn`. Failures
-   * of the background time-index PUT never propagate to the
-   * `createThread` caller — they are observed exclusively through
-   * this channel.
+   * Background time-index PUT failures are logged here and never
+   * propagated to `createThread` callers.
    */
   logger?: OSSAgentStoreWarnLogger;
-  /**
-   * IANA timezone name (or the case-insensitive literal `'UTC'`) used
-   * to compute the `YYYY-MM-DD` date-bucket directory of the time
-   * index. Defaults to `'UTC'` so that workers in physically different
-   * regions agree on a single partition for a given absolute instant.
-   * Set to e.g. `'Asia/Shanghai'` when the analytics calendar follows
-   * a specific local timezone.
-   */
-  dateTimezone?: string;
 }
 
 /**
@@ -77,55 +49,13 @@ type ThreadMetadata = Omit<ThreadRecord, 'messages'>;
  * {prefix}index/threads-by-date/{YYYY-MM-DD}/{revMs13}_{threadId} — Time-index sidecar (JSON body)
  * ```
  *
- * The time-index sidecar is a write-only, analytics-facing artifact:
- * it is created best-effort during `createThread`, never read by
- * `getThread`, and never mutated by `appendMessages` / `createRun` /
- * `updateRun`. Within a date-bucket directory the keys sort
- * newest-first under the ASC-only `ListObjects` semantics that OSS /
- * S3 expose, because the `revMs13` segment is the decimal complement
- * of the creation timestamp (see `reverseMs` in
- * `AgentStoreUtils.ts`). Across date buckets the directories sort
- * calendar-ascending, so a consumer that wants the globally newest N
- * threads enumerates the date prefixes in reverse-calendar order and
- * walks each one's contents in dictionary order.
- *
- * The body of each index object is a compact JSON document carrying
- * `{ threadId, createdAt, metadata }`, mirroring the
- * `threads/{id}/meta.json`'s `createdAt` field. Both timestamp values
- * derive from a single `Date.now()` call inside `createThread`, so
- * the seconds-precision meta value and the millisecond-precision
- * index-key value reflect the same physical instant and cannot
- * disagree across a date boundary.
- *
- * The index PUT itself is intentionally fire-and-forget. It runs on a
- * background promise registered in the `pendingIndexWrites` Set,
- * contributes zero latency to `createThread`'s happy path, and any
- * rejection becomes a single warn-log line via the injected
- * `OSSAgentStoreWarnLogger`. The Set lets `destroy()` (the standard
- * Egg.js `beforeClose` cleanup point for this kind of resource) wait
- * for the in-flight writes to settle via the public
- * `awaitPendingWrites()` method.
+ * The time-index sidecar is best-effort and write-only. It is not read
+ * by `getThread`, and `destroy()` drains any in-flight index writes.
  */
 export class OSSAgentStore implements AgentStore {
   private readonly client: ObjectStorageClient;
   private readonly prefix: string;
   private readonly logger: OSSAgentStoreWarnLogger;
-  private readonly dateTimezone: string;
-  /**
-   * Background time-index PUT promises that are still in flight. Each
-   * promise installs a `.then(success, failure)` handler at the
-   * bottom of `createThread` that removes the promise from the Set
-   * when it settles, so the Set's membership exactly matches the
-   * in-flight set at every observation point.
-   *
-   * `awaitPendingWrites()` and `destroy()` drain the Set. The drain
-   * is a loop over fresh `[...this.pendingIndexWrites]` snapshots,
-   * not a one-shot `Promise.allSettled` against a single snapshot,
-   * so that a `createThread` invocation that lands during the
-   * shutdown sequence still gets its background write awaited — the
-   * spread-operator snapshot would otherwise have already been taken
-   * and the late-arrival would slip through.
-   */
   private readonly pendingIndexWrites = new Set<Promise<void>>();
 
   constructor(options: OSSAgentStoreOptions) {
@@ -133,7 +63,6 @@ export class OSSAgentStore implements AgentStore {
     const raw = options.prefix ?? '';
     this.prefix = raw && !raw.endsWith('/') ? raw + '/' : raw;
     this.logger = options.logger ?? { warn: (message, ...args) => console.warn(message, ...args) };
-    this.dateTimezone = options.dateTimezone ?? 'UTC';
   }
 
   private threadMetaKey(threadId: string): string {
@@ -148,18 +77,8 @@ export class OSSAgentStore implements AgentStore {
     return `${this.prefix}runs/${runId}.json`;
   }
 
-  /**
-   * Compose the time-index sidecar key for a thread created at the
-   * given millisecond timestamp. `dateBucket` resolves the IANA
-   * timezone to a `YYYY-MM-DD` directory name and `reverseMs`
-   * produces the decimal-complement suffix that gives newest-first
-   * ordering under the standard dictionary-order `ListObjects`
-   * semantics. The full `threadId` is appended verbatim so a
-   * downstream consumer can read it directly from the OSS key
-   * without opening the object body.
-   */
   private threadTimeIndexKey(nowMs: number, threadId: string): string {
-    const date = dateBucket(nowMs, this.dateTimezone);
+    const date = dateBucket(nowMs);
     const rev = reverseMs(nowMs);
     return `${this.prefix}index/threads-by-date/${date}/${rev}_${threadId}`;
   }
@@ -169,54 +88,14 @@ export class OSSAgentStore implements AgentStore {
   }
 
   async destroy(): Promise<void> {
-    // Drain the in-flight background time-index writes before
-    // tearing down the underlying client. The drain loop in
-    // `awaitPendingWrites` swallows individual failures (which the
-    // catch handler in `createThread` has already turned into
-    // warn-log lines), so `destroy` itself does not reject because
-    // of an index-write miss.
     await this.awaitPendingWrites();
     await this.client.destroy?.();
   }
 
   /**
-   * Wait for every in-flight background time-index write to settle
-   * (resolve or reject). Called internally by `destroy()` to keep
-   * graceful shutdown from losing writes, and exposed publicly for
-   * tests and external callers that need an explicit drain
-   * checkpoint.
-   *
-   * Never rejects: individual write failures have already been
-   * converted into warn-log lines by the catch handler installed in
-   * the background-write chain inside `createThread`.
-   *
-   * The drain is a `while`-loop over fresh
-   * `[...this.pendingIndexWrites]` snapshots rather than a single
-   * `Promise.allSettled` against a one-shot snapshot. This handles
-   * the edge case where a caller invokes `createThread` while a
-   * drain is in progress: the spread-operator snapshot is taken at
-   * the moment the `Promise.allSettled` call is constructed, and
-   * any background promise added to the Set after that moment is
-   * not in the snapshot and would not be waited on by that
-   * particular `allSettled`. The surrounding `while` loop notices
-   * the Set is still non-empty after the previous iteration's
-   * `allSettled` returns (the late-arrival is the only entry left,
-   * having survived because it wasn't in the snapshot the previous
-   * iteration awaited) and takes a fresh snapshot to wait on its
-   * settlement.
-   *
-   * The loop terminates as long as each individual background write
-   * eventually settles. In the standard Egg.js shutdown sequence
-   * the request handlers have already returned by the time
-   * `beforeClose` fires (and therefore by the time `destroy()` and
-   * this method are called), so there is no live caller of
-   * `createThread` during the drain and the loop almost always
-   * exits on the second iteration's `size === 0` check. The
-   * abstract pattern of "graceful shutdown waits for the in-flight
-   * background-task set to clear" matches the `BackgroundTaskHelper`
-   * in `@eggjs/tegg-runtime`, which the project root's `CLAUDE.md`
-   * "Use BackgroundTaskHelper for Async Tasks" section flags as the
-   * canonical drain idiom in the tegg ecosystem.
+   * Wait for in-flight background time-index writes. Individual write
+   * failures are logged by `createThread`, so this method never rejects
+   * for index-write failures.
    */
   async awaitPendingWrites(): Promise<void> {
     while (this.pendingIndexWrites.size > 0) {
@@ -226,12 +105,6 @@ export class OSSAgentStore implements AgentStore {
 
   async createThread(metadata?: Record<string, unknown>): Promise<ThreadRecord> {
     const threadId = newThreadId();
-    // Take the wall clock exactly once. The seconds value that goes
-    // into `meta.createdAt` and the milliseconds value encoded into
-    // the time-index key both derive from this single observation, so
-    // they cannot drift across a millisecond boundary — and, in the
-    // worst-case midnight corner, cannot land in different
-    // date-bucket directories.
     const nowMs = Date.now();
     const createdAt = Math.floor(nowMs / 1000);
     const meta: ThreadMetadata = {
@@ -240,33 +113,8 @@ export class OSSAgentStore implements AgentStore {
       metadata: metadata ?? {},
       createdAt,
     };
-    // 1) Main path: the canonical `threads/{id}/meta.json` PUT.
-    // Failure here surfaces to the caller exactly as it did before
-    // the time-index feature was introduced — the
-    // pre-time-index behavior of `createThread` is preserved.
     await this.client.put(this.threadMetaKey(threadId), JSON.stringify(meta));
 
-    // 2) Time-index sidecar PUT, fire-and-forget. The promise is
-    // tracked in `pendingIndexWrites` so `awaitPendingWrites()`
-    // (called by `destroy()`) can drain it during a graceful
-    // shutdown, but `createThread` does not await its settlement
-    // and the caller sees zero added latency on the happy path.
-    //
-    // A rejection is caught by the second arm of the two-arg
-    // `.then(success, failure)` form below, which is the idiomatic
-    // way to silence the unhandled-promise-rejection warning
-    // without inserting a separate `.catch` chain. The Error object
-    // is passed verbatim as the un-interpolated trailing argument
-    // to `logger.warn` so the underlying `util.format`-style
-    // renderer (in Node's `console.warn` and in `egg-logger`'s
-    // `EggLogger.warn`) reaches for `util.inspect`, which on an
-    // `Error` instance prints the stack trace and the
-    // `Error.cause` chain — the property that the AI-reviewer
-    // feedback on the original PR's first revision asked for. An
-    // earlier draft stringified the Error to its `.message` ahead
-    // of the warn call, which produced the message-only
-    // `"Error: <text>"` form without a stack; the present shape
-    // preserves the stack.
     const indexKey = this.threadTimeIndexKey(nowMs, threadId);
     const indexBody = JSON.stringify({
       threadId,
@@ -275,36 +123,10 @@ export class OSSAgentStore implements AgentStore {
     });
     const tracked: Promise<void> = this.client.put(indexKey, indexBody).then(
       () => {
-        // Run-to-completion note: this `tracked` reference resolves
-        // to the same binding the outer-scope `const tracked = ...`
-        // line assigns, because JavaScript's synchronous body of
-        // the surrounding function (the synchronous portion of
-        // `createThread` from the `Date.now()` call through the
-        // `this.pendingIndexWrites.add(tracked)` line that follows
-        // this `.then`-arg expression) completes before any
-        // microtask handler attached by `.then` is allowed to run.
-        // So by the time this success handler executes, `tracked`
-        // is bound to the value of the right-hand side of its own
-        // declaration — the `Promise<void>` produced by the
-        // `this.client.put(...).then(...)` chain. The Set's
-        // `delete` then-removes the same Promise object that was
-        // added to it on the line after the assignment.
         this.pendingIndexWrites.delete(tracked);
       },
       (err: unknown) => {
         this.pendingIndexWrites.delete(tracked);
-        // Wrap non-`Error` rejection values once so the trailing
-        // arg always has a stack. JavaScript allows `throw <any
-        // value>`, so a rejecting promise's reason can in principle
-        // be a string, a plain object, or any other non-Error
-        // thing; the wrap site's freshly-constructed Error gives at
-        // least the catch handler's own stack frame as a
-        // traceback, which is better than a bare-string log entry.
-        // For the common case where the underlying client rejected
-        // with an actual `Error` (e.g. ali-oss-client's
-        // `NoSuchKey` or `AccessDenied`), the original Error
-        // passes through unchanged and its stack reaches the log
-        // intact.
         const errForLog: Error = err instanceof Error ? err : new Error(String(err));
         this.logger.warn(
           '[OSSAgentStore] failed to write thread time index threadId=%s key=%s',

--- a/core/agent-runtime/src/OSSAgentStore.ts
+++ b/core/agent-runtime/src/OSSAgentStore.ts
@@ -12,7 +12,7 @@ import { AgentObjectType, RunStatus, AgentNotFoundError } from '@eggjs/tegg-type
 import { dateBucket, newRunId, newThreadId, nowUnix, reverseMs } from './AgentStoreUtils';
 
 /**
- * Warn logger used when a background thread-time-index write fails.
+ * Warn logger used when a background thread activity-index write fails.
  * `console` and `egg-logger` both satisfy this shape.
  */
 export interface OSSAgentStoreWarnLogger {
@@ -23,8 +23,8 @@ export interface OSSAgentStoreOptions {
   client: ObjectStorageClient;
   prefix?: string;
   /**
-   * Background time-index PUT failures are logged here and never
-   * propagated to `createThread` callers.
+   * Background activity-index PUT failures are logged here and never
+   * propagated to store callers.
    */
   logger?: OSSAgentStoreWarnLogger;
 }
@@ -46,10 +46,10 @@ type ThreadMetadata = Omit<ThreadRecord, 'messages'>;
  * {prefix}threads/{id}/meta.json                                  — Thread metadata (JSON, source of truth)
  * {prefix}threads/{id}/messages.jsonl                             — Messages (JSONL, one AgentMessage per line)
  * {prefix}runs/{id}.json                                          — Run record (JSON)
- * {prefix}index/threads-by-date/{YYYY-MM-DD}/{revMs13}_{threadId} — Time-index sidecar (JSON body)
+ * {prefix}index/threads-by-updated-date/{YYYY-MM-DD}/{revMs13}_{threadId} — Activity-time index sidecar (JSON body)
  * ```
  *
- * The time-index sidecar is best-effort and write-only. It is not read
+ * The activity-time index sidecar is best-effort and write-only. It is not read
  * by `getThread`, and `destroy()` drains any in-flight index writes.
  */
 export class OSSAgentStore implements AgentStore {
@@ -77,10 +77,39 @@ export class OSSAgentStore implements AgentStore {
     return `${this.prefix}runs/${runId}.json`;
   }
 
-  private threadTimeIndexKey(nowMs: number, threadId: string): string {
+  private threadActivityIndexKey(nowMs: number, threadId: string): string {
     const date = dateBucket(nowMs);
     const rev = reverseMs(nowMs);
-    return `${this.prefix}index/threads-by-date/${date}/${rev}_${threadId}`;
+    return `${this.prefix}index/threads-by-updated-date/${date}/${rev}_${threadId}`;
+  }
+
+  private writeThreadActivityIndex(
+    threadId: string,
+    createdAt: number,
+    updatedAtMs: number,
+    metadata: Record<string, unknown>,
+  ): void {
+    const indexKey = this.threadActivityIndexKey(updatedAtMs, threadId);
+    const indexBody = JSON.stringify({
+      threadId,
+      createdAt,
+      updatedAt: Math.floor(updatedAtMs / 1000),
+      metadata,
+    });
+    const tracked: Promise<void> = this.client.put(indexKey, indexBody)
+      .catch((err: unknown) => {
+        const errForLog: Error = err instanceof Error ? err : new Error(String(err));
+        this.logger.warn(
+          '[OSSAgentStore] failed to write thread activity index threadId=%s key=%s',
+          threadId,
+          indexKey,
+          errForLog,
+        );
+      })
+      .finally(() => {
+        this.pendingIndexWrites.delete(tracked);
+      });
+    this.pendingIndexWrites.add(tracked);
   }
 
   async init(): Promise<void> {
@@ -93,9 +122,9 @@ export class OSSAgentStore implements AgentStore {
   }
 
   /**
-   * Wait for in-flight background time-index writes. Individual write
-   * failures are logged by `createThread`, so this method never rejects
-   * for index-write failures.
+   * Wait for in-flight background activity-index writes. Individual write
+   * failures are logged when scheduled, so this method never rejects
+   * for index-write failures. The set size is bounded by in-flight index PUTs.
    */
   async awaitPendingWrites(): Promise<void> {
     while (this.pendingIndexWrites.size > 0) {
@@ -115,28 +144,7 @@ export class OSSAgentStore implements AgentStore {
     };
     await this.client.put(this.threadMetaKey(threadId), JSON.stringify(meta));
 
-    const indexKey = this.threadTimeIndexKey(nowMs, threadId);
-    const indexBody = JSON.stringify({
-      threadId,
-      createdAt,
-      metadata: meta.metadata,
-    });
-    const tracked: Promise<void> = this.client.put(indexKey, indexBody).then(
-      () => {
-        this.pendingIndexWrites.delete(tracked);
-      },
-      (err: unknown) => {
-        this.pendingIndexWrites.delete(tracked);
-        const errForLog: Error = err instanceof Error ? err : new Error(String(err));
-        this.logger.warn(
-          '[OSSAgentStore] failed to write thread time index threadId=%s key=%s',
-          threadId,
-          indexKey,
-          errForLog,
-        );
-      },
-    );
-    this.pendingIndexWrites.add(tracked);
+    this.writeThreadActivityIndex(threadId, createdAt, nowMs, meta.metadata);
 
     return { ...meta, messages: [] };
   }
@@ -177,6 +185,8 @@ export class OSSAgentStore implements AgentStore {
       throw new AgentNotFoundError(`Thread ${threadId} not found`);
     }
     if (messages.length === 0) return;
+    const meta = JSON.parse(metaData) as ThreadMetadata;
+    const nowMs = Date.now();
 
     const lines = messages.map(m => JSON.stringify(m)).join('\n') + '\n';
     const messagesKey = this.threadMessagesKey(threadId);
@@ -187,6 +197,7 @@ export class OSSAgentStore implements AgentStore {
       const existing = (await this.client.get(messagesKey)) ?? '';
       await this.client.put(messagesKey, existing + lines);
     }
+    this.writeThreadActivityIndex(threadId, meta.createdAt, nowMs, meta.metadata);
   }
 
   async createRun(

--- a/core/agent-runtime/src/OSSAgentStore.ts
+++ b/core/agent-runtime/src/OSSAgentStore.ts
@@ -13,9 +13,23 @@ import { dateBucket, newRunId, newThreadId, nowUnix, reverseMs } from './AgentSt
 
 /**
  * Minimal structural type for the warn-logging channel used when a
- * background thread-time-index write fails. Both `egg-logger`'s `EggLogger`
- * and the global `console` satisfy this shape, so applications can pass
- * `app.logger` directly without an explicit import.
+ * background thread-time-index write fails. Both `egg-logger`'s
+ * `EggLogger` and the global `console` satisfy this shape, so
+ * applications can pass `app.logger` directly without importing any
+ * egg-specific types here.
+ *
+ * The implementation is expected to follow Node's `util.format`
+ * conventions: leading args fill the `%s` / `%d` / `%j` / `%o` / `%O`
+ * placeholders in the format string, and any trailing args beyond the
+ * placeholder count are appended to the rendered output via
+ * `util.inspect`. For an `Error` instance in a trailing slot
+ * `util.inspect` includes the stack trace and any `Error.cause` chain,
+ * which is the property the warn-on-index-failure call site relies on
+ * for observability. Both `console.warn` and `EggLogger.warn` honor
+ * the `util.format` convention; a custom structured logger that does
+ * not implement `%s`-interpolation may render the format string and
+ * the args differently, which is a known idiomatic-difference between
+ * the printf-style and the structured-log conventions.
  */
 export interface OSSAgentStoreWarnLogger {
   warn(message: string, ...args: unknown[]): void;
@@ -25,29 +39,34 @@ export interface OSSAgentStoreOptions {
   client: ObjectStorageClient;
   prefix?: string;
   /**
-   * Sink for warn messages emitted when the background time-index PUT fails.
-   * Defaults to a wrapper around `console.warn`. Failures never surface to
-   * the `createThread` caller — they are observed exclusively via this logger.
+   * Sink for warn messages emitted when the background time-index PUT
+   * fails. Defaults to a thin wrapper around `console.warn`. Failures
+   * of the background time-index PUT never propagate to the
+   * `createThread` caller — they are observed exclusively through
+   * this channel.
    */
   logger?: OSSAgentStoreWarnLogger;
   /**
-   * IANA timezone name (or the literal `'UTC'`) used to compute the
-   * `YYYY-MM-DD` date-bucket directory of the time index. Defaults to
-   * `'UTC'` so that workers in different physical regions agree on a single
-   * partition for a given absolute instant. Set to e.g. `'Asia/Shanghai'`
-   * when the analytics calendar follows a specific local timezone.
+   * IANA timezone name (or the case-insensitive literal `'UTC'`) used
+   * to compute the `YYYY-MM-DD` date-bucket directory of the time
+   * index. Defaults to `'UTC'` so that workers in physically different
+   * regions agree on a single partition for a given absolute instant.
+   * Set to e.g. `'Asia/Shanghai'` when the analytics calendar follows
+   * a specific local timezone.
    */
   dateTimezone?: string;
 }
 
 /**
  * Thread metadata stored as a JSON object (excludes messages).
- * Messages are stored separately in a JSONL file for append-friendly writes.
+ * Messages are stored separately in a JSONL file for append-friendly
+ * writes.
  */
 type ThreadMetadata = Omit<ThreadRecord, 'messages'>;
 
 /**
- * AgentStore implementation backed by an ObjectStorageClient (OSS, S3, etc.).
+ * `AgentStore` implementation backed by an `ObjectStorageClient` (OSS,
+ * S3, etc.).
  *
  * ## Storage layout
  *
@@ -55,26 +74,37 @@ type ThreadMetadata = Omit<ThreadRecord, 'messages'>;
  * {prefix}threads/{id}/meta.json                                  — Thread metadata (JSON, source of truth)
  * {prefix}threads/{id}/messages.jsonl                             — Messages (JSONL, one AgentMessage per line)
  * {prefix}runs/{id}.json                                          — Run record (JSON)
- * {prefix}index/threads-by-date/{YYYY-MM-DD}/{revMs13}_{threadId} — Time index sidecar, body JSON
+ * {prefix}index/threads-by-date/{YYYY-MM-DD}/{revMs13}_{threadId} — Time-index sidecar (JSON body)
  * ```
  *
- * The time-index sidecar is a write-only, analytics-facing artifact: it is
- * created best-effort inside `createThread`, never read by `getThread`, and
- * never mutated by `appendMessages` / `createRun` / `updateRun`. Its
- * filename's `revMs13` segment is the decimal complement of the
- * millisecond-precision creation timestamp (see `reverseMs` in
- * `AgentStoreUtils`), which makes the natural ASC-by-key dictionary order
- * of a date directory equivalent to time-DESC order — a workaround for the
- * fact that the OSS / S3 ListObjects API has no reverse-order option. The
- * body is a compact JSON document carrying `{ threadId, createdAt, metadata }`
- * so that consumers reading only the index never need to GET `meta.json`.
+ * The time-index sidecar is a write-only, analytics-facing artifact:
+ * it is created best-effort during `createThread`, never read by
+ * `getThread`, and never mutated by `appendMessages` / `createRun` /
+ * `updateRun`. Within a date-bucket directory the keys sort
+ * newest-first under the ASC-only `ListObjects` semantics that OSS /
+ * S3 expose, because the `revMs13` segment is the decimal complement
+ * of the creation timestamp (see `reverseMs` in
+ * `AgentStoreUtils.ts`). Across date buckets the directories sort
+ * calendar-ascending, so a consumer that wants the globally newest N
+ * threads enumerates the date prefixes in reverse-calendar order and
+ * walks each one's contents in dictionary order.
  *
- * The index PUT is fire-and-forget: it runs on a background promise tracked
- * in `pendingIndexWrites`, contributes zero latency to `createThread`'s
- * happy path, and a failure produces a single `warn` line via the injected
- * `logger` instead of propagating. Call `awaitPendingWrites()` (or
- * `destroy()`, which calls it internally) when graceful shutdown must wait
- * for in-flight index writes to settle.
+ * The body of each index object is a compact JSON document carrying
+ * `{ threadId, createdAt, metadata }`, mirroring the
+ * `threads/{id}/meta.json`'s `createdAt` field. Both timestamp values
+ * derive from a single `Date.now()` call inside `createThread`, so
+ * the seconds-precision meta value and the millisecond-precision
+ * index-key value reflect the same physical instant and cannot
+ * disagree across a date boundary.
+ *
+ * The index PUT itself is intentionally fire-and-forget. It runs on a
+ * background promise registered in the `pendingIndexWrites` Set,
+ * contributes zero latency to `createThread`'s happy path, and any
+ * rejection becomes a single warn-log line via the injected
+ * `OSSAgentStoreWarnLogger`. The Set lets `destroy()` (the standard
+ * Egg.js `beforeClose` cleanup point for this kind of resource) wait
+ * for the in-flight writes to settle via the public
+ * `awaitPendingWrites()` method.
  */
 export class OSSAgentStore implements AgentStore {
   private readonly client: ObjectStorageClient;
@@ -82,9 +112,19 @@ export class OSSAgentStore implements AgentStore {
   private readonly logger: OSSAgentStoreWarnLogger;
   private readonly dateTimezone: string;
   /**
-   * Background index writes that have not yet settled. Each promise removes
-   * itself from the set on resolution or rejection, so the set never grows
-   * unboundedly. `awaitPendingWrites()` and `destroy()` drain it.
+   * Background time-index PUT promises that are still in flight. Each
+   * promise installs a `.then(success, failure)` handler at the
+   * bottom of `createThread` that removes the promise from the Set
+   * when it settles, so the Set's membership exactly matches the
+   * in-flight set at every observation point.
+   *
+   * `awaitPendingWrites()` and `destroy()` drain the Set. The drain
+   * is a loop over fresh `[...this.pendingIndexWrites]` snapshots,
+   * not a one-shot `Promise.allSettled` against a single snapshot,
+   * so that a `createThread` invocation that lands during the
+   * shutdown sequence still gets its background write awaited — the
+   * spread-operator snapshot would otherwise have already been taken
+   * and the late-arrival would slip through.
    */
   private readonly pendingIndexWrites = new Set<Promise<void>>();
 
@@ -109,10 +149,14 @@ export class OSSAgentStore implements AgentStore {
   }
 
   /**
-   * Compose the time-index sidecar key for a thread created at `nowMs`.
-   * `dateBucket` resolves the timezone, `reverseMs` produces the complement
-   * suffix; the threadId is appended verbatim so that consumers can read it
-   * from the key without GETting the body.
+   * Compose the time-index sidecar key for a thread created at the
+   * given millisecond timestamp. `dateBucket` resolves the IANA
+   * timezone to a `YYYY-MM-DD` directory name and `reverseMs`
+   * produces the decimal-complement suffix that gives newest-first
+   * ordering under the standard dictionary-order `ListObjects`
+   * semantics. The full `threadId` is appended verbatim so a
+   * downstream consumer can read it directly from the OSS key
+   * without opening the object body.
    */
   private threadTimeIndexKey(nowMs: number, threadId: string): string {
     const date = dateBucket(nowMs, this.dateTimezone);
@@ -125,34 +169,69 @@ export class OSSAgentStore implements AgentStore {
   }
 
   async destroy(): Promise<void> {
-    // Drain pending background index writes before tearing down the
-    // underlying client. `Promise.allSettled` swallows individual failures
-    // (which are already surfaced via the logger), so destroy() itself
-    // never rejects because of an index miss.
+    // Drain the in-flight background time-index writes before
+    // tearing down the underlying client. The drain loop in
+    // `awaitPendingWrites` swallows individual failures (which the
+    // catch handler in `createThread` has already turned into
+    // warn-log lines), so `destroy` itself does not reject because
+    // of an index-write miss.
     await this.awaitPendingWrites();
     await this.client.destroy?.();
   }
 
   /**
-   * Wait for every in-flight background time-index write to settle (either
-   * resolve or reject). Used internally by `destroy()` to keep graceful
-   * shutdown from dropping writes, and exposed publicly for tests and
-   * external callers that need an explicit drain point.
+   * Wait for every in-flight background time-index write to settle
+   * (resolve or reject). Called internally by `destroy()` to keep
+   * graceful shutdown from losing writes, and exposed publicly for
+   * tests and external callers that need an explicit drain
+   * checkpoint.
    *
-   * Never rejects — individual write failures have already been turned into
-   * `warn` log entries by the catch handler installed in `createThread`.
+   * Never rejects: individual write failures have already been
+   * converted into warn-log lines by the catch handler installed in
+   * the background-write chain inside `createThread`.
+   *
+   * The drain is a `while`-loop over fresh
+   * `[...this.pendingIndexWrites]` snapshots rather than a single
+   * `Promise.allSettled` against a one-shot snapshot. This handles
+   * the edge case where a caller invokes `createThread` while a
+   * drain is in progress: the spread-operator snapshot is taken at
+   * the moment the `Promise.allSettled` call is constructed, and
+   * any background promise added to the Set after that moment is
+   * not in the snapshot and would not be waited on by that
+   * particular `allSettled`. The surrounding `while` loop notices
+   * the Set is still non-empty after the previous iteration's
+   * `allSettled` returns (the late-arrival is the only entry left,
+   * having survived because it wasn't in the snapshot the previous
+   * iteration awaited) and takes a fresh snapshot to wait on its
+   * settlement.
+   *
+   * The loop terminates as long as each individual background write
+   * eventually settles. In the standard Egg.js shutdown sequence
+   * the request handlers have already returned by the time
+   * `beforeClose` fires (and therefore by the time `destroy()` and
+   * this method are called), so there is no live caller of
+   * `createThread` during the drain and the loop almost always
+   * exits on the second iteration's `size === 0` check. The
+   * abstract pattern of "graceful shutdown waits for the in-flight
+   * background-task set to clear" matches the `BackgroundTaskHelper`
+   * in `@eggjs/tegg-runtime`, which the project root's `CLAUDE.md`
+   * "Use BackgroundTaskHelper for Async Tasks" section flags as the
+   * canonical drain idiom in the tegg ecosystem.
    */
   async awaitPendingWrites(): Promise<void> {
-    if (this.pendingIndexWrites.size === 0) return;
-    await Promise.allSettled([ ...this.pendingIndexWrites ]);
+    while (this.pendingIndexWrites.size > 0) {
+      await Promise.allSettled([ ...this.pendingIndexWrites ]);
+    }
   }
 
   async createThread(metadata?: Record<string, unknown>): Promise<ThreadRecord> {
     const threadId = newThreadId();
-    // Take the wall-clock once so the seconds value written into `meta.createdAt`
-    // and the millisecond value encoded into the index key derive from the same
-    // physical instant. Two separate `Date.now()` reads could disagree across
-    // a millisecond boundary and, near midnight, even across the date bucket.
+    // Take the wall clock exactly once. The seconds value that goes
+    // into `meta.createdAt` and the milliseconds value encoded into
+    // the time-index key both derive from this single observation, so
+    // they cannot drift across a millisecond boundary — and, in the
+    // worst-case midnight corner, cannot land in different
+    // date-bucket directories.
     const nowMs = Date.now();
     const createdAt = Math.floor(nowMs / 1000);
     const meta: ThreadMetadata = {
@@ -161,15 +240,33 @@ export class OSSAgentStore implements AgentStore {
       metadata: metadata ?? {},
       createdAt,
     };
-    // 1) Main path. Failure surfaces to the caller exactly as before.
+    // 1) Main path: the canonical `threads/{id}/meta.json` PUT.
+    // Failure here surfaces to the caller exactly as it did before
+    // the time-index feature was introduced — the
+    // pre-time-index behavior of `createThread` is preserved.
     await this.client.put(this.threadMetaKey(threadId), JSON.stringify(meta));
 
-    // 2) Time-index sidecar. Fire-and-forget: the promise is tracked in
-    //    `pendingIndexWrites` so graceful shutdown can drain it, but
-    //    `createThread` does not await it and a rejection produces a
-    //    warn log rather than propagating. The two-arg `.then(success,
-    //    failure)` form serves both as a handler and as the standard
-    //    means of silencing the unhandled-rejection warning.
+    // 2) Time-index sidecar PUT, fire-and-forget. The promise is
+    // tracked in `pendingIndexWrites` so `awaitPendingWrites()`
+    // (called by `destroy()`) can drain it during a graceful
+    // shutdown, but `createThread` does not await its settlement
+    // and the caller sees zero added latency on the happy path.
+    //
+    // A rejection is caught by the second arm of the two-arg
+    // `.then(success, failure)` form below, which is the idiomatic
+    // way to silence the unhandled-promise-rejection warning
+    // without inserting a separate `.catch` chain. The Error object
+    // is passed verbatim as the un-interpolated trailing argument
+    // to `logger.warn` so the underlying `util.format`-style
+    // renderer (in Node's `console.warn` and in `egg-logger`'s
+    // `EggLogger.warn`) reaches for `util.inspect`, which on an
+    // `Error` instance prints the stack trace and the
+    // `Error.cause` chain — the property that the AI-reviewer
+    // feedback on the original PR's first revision asked for. An
+    // earlier draft stringified the Error to its `.message` ahead
+    // of the warn call, which produced the message-only
+    // `"Error: <text>"` form without a stack; the present shape
+    // preserves the stack.
     const indexKey = this.threadTimeIndexKey(nowMs, threadId);
     const indexBody = JSON.stringify({
       threadId,
@@ -178,16 +275,42 @@ export class OSSAgentStore implements AgentStore {
     });
     const tracked: Promise<void> = this.client.put(indexKey, indexBody).then(
       () => {
+        // Run-to-completion note: this `tracked` reference resolves
+        // to the same binding the outer-scope `const tracked = ...`
+        // line assigns, because JavaScript's synchronous body of
+        // the surrounding function (the synchronous portion of
+        // `createThread` from the `Date.now()` call through the
+        // `this.pendingIndexWrites.add(tracked)` line that follows
+        // this `.then`-arg expression) completes before any
+        // microtask handler attached by `.then` is allowed to run.
+        // So by the time this success handler executes, `tracked`
+        // is bound to the value of the right-hand side of its own
+        // declaration — the `Promise<void>` produced by the
+        // `this.client.put(...).then(...)` chain. The Set's
+        // `delete` then-removes the same Promise object that was
+        // added to it on the line after the assignment.
         this.pendingIndexWrites.delete(tracked);
       },
       (err: unknown) => {
         this.pendingIndexWrites.delete(tracked);
-        const message = err instanceof Error ? err.message : String(err);
+        // Wrap non-`Error` rejection values once so the trailing
+        // arg always has a stack. JavaScript allows `throw <any
+        // value>`, so a rejecting promise's reason can in principle
+        // be a string, a plain object, or any other non-Error
+        // thing; the wrap site's freshly-constructed Error gives at
+        // least the catch handler's own stack frame as a
+        // traceback, which is better than a bare-string log entry.
+        // For the common case where the underlying client rejected
+        // with an actual `Error` (e.g. ali-oss-client's
+        // `NoSuchKey` or `AccessDenied`), the original Error
+        // passes through unchanged and its stack reaches the log
+        // intact.
+        const errForLog: Error = err instanceof Error ? err : new Error(String(err));
         this.logger.warn(
-          '[OSSAgentStore] failed to write thread time index threadId=%s key=%s err=%s',
+          '[OSSAgentStore] failed to write thread time index threadId=%s key=%s',
           threadId,
           indexKey,
-          message,
+          errForLog,
         );
       },
     );
@@ -214,10 +337,11 @@ export class OSSAgentStore implements AgentStore {
         .map(line => JSON.parse(line) as AgentMessage)
       : [];
 
-    // By default only return conversation messages (user + assistant),
-    // aligned with SDK's getSessionMessages behavior.
-    // The JSONL file stores all message types as a complete event log;
-    // this filter provides the application-level conversation view.
+    // By default only return the conversation-shape messages (user +
+    // assistant), matching the SDK's `getSessionMessages` semantics.
+    // The JSONL file is the full event log including framework-level
+    // entries (system events, tool results, etc.); the filter
+    // narrows the visible set to the application-level conversation.
     if (!options?.includeAllMessages) {
       messages = messages.filter(m => m.type === 'user' || m.type === 'assistant');
     }

--- a/core/agent-runtime/test/AgentStoreUtils.test.ts
+++ b/core/agent-runtime/test/AgentStoreUtils.test.ts
@@ -24,10 +24,13 @@ describe('test/AgentStoreUtils.test.ts', () => {
       assert.strictEqual(reverseMs(1).length, 13);
     });
 
-    it('matches a known timestamp from the design document', () => {
-      // 2025-11-13T08:00:00.000Z (= 1_763_020_800_000) — pulled from the
-      // worked example in /Users/jerry/.claude/plans/wobbly-swinging-sparkle.md.
-      // The expected complement is 9_999_999_999_999 - 1_763_020_800_000 = 8_236_979_199_999.
+    it('matches the worked example timestamp from the PR description', () => {
+      // The PR description's worked example uses the instant
+      // 2025-11-13T08:00:00.000Z, which is the Unix-millisecond value
+      // 1_763_020_800_000. The decimal complement against TS_MAX_MS is
+      // 9_999_999_999_999 - 1_763_020_800_000 = 8_236_979_199_999. This
+      // assertion pins the algebra so any drift in the encoding helper
+      // is caught immediately.
       const knownMs = Date.UTC(2025, 10, 13, 8, 0, 0, 0);
       assert.strictEqual(knownMs, 1_763_020_800_000);
       assert.strictEqual(reverseMs(knownMs), '8236979199999');
@@ -44,8 +47,9 @@ describe('test/AgentStoreUtils.test.ts', () => {
 
     it('is strictly monotonically decreasing in lex order versus the input', () => {
       // Pairs where the first element is strictly less than the second.
-      // Lexicographic comparison on equal-length decimal strings is the same
-      // as numeric comparison; we use the natural String '<'/'>' operators.
+      // Lexicographic comparison on equal-length decimal strings is
+      // identical to numeric comparison, so we use the natural String
+      // `<` / `>` operators.
       const pairs: Array<[number, number]> = [
         [ 0, 1 ],
         [ 0, TS_MAX_MS ],
@@ -91,13 +95,6 @@ describe('test/AgentStoreUtils.test.ts', () => {
       assert.strictEqual(decodeReverseMs('0000000000000'), TS_MAX_MS);
       assert.strictEqual(decodeReverseMs('9999999999999'), 0);
     });
-
-    it('throws TypeError when the input cannot be parsed as a decimal integer', () => {
-      assert.throws(() => decodeReverseMs('abc'), TypeError);
-      assert.throws(() => decodeReverseMs(''), TypeError);
-      // Leading non-digit text. `parseInt` returns NaN.
-      assert.throws(() => decodeReverseMs('xx0000'), TypeError);
-    });
   });
 
   describe('dateBucket', () => {
@@ -107,7 +104,7 @@ describe('test/AgentStoreUtils.test.ts', () => {
       assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 12, 34, 56, 789)), '2025-11-13');
       // Last millisecond of the UTC day stays in that day.
       assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 23, 59, 59, 999)), '2025-11-13');
-      // Adding one ms crosses the UTC midnight.
+      // Adding one ms crosses the UTC midnight boundary.
       assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 23, 59, 59, 999) + 1), '2025-11-14');
     });
 
@@ -118,25 +115,70 @@ describe('test/AgentStoreUtils.test.ts', () => {
       assert.strictEqual(dateBucket(t, 'Utc'), dateBucket(t));
     });
 
-    it('honors a named IANA timezone via Intl.DateTimeFormat', () => {
-      // UTC 16:00 on 2025-11-13 is 2025-11-14T00:00 in Asia/Shanghai (UTC+8, no DST).
+    it('honors a named IANA timezone (via dayjs\'s timezone plugin under the hood)', () => {
+      // UTC 16:00 on 2025-11-13 is 2025-11-14T00:00 in Asia/Shanghai
+      // (UTC+8, no DST in the Asia/Shanghai zone). dayjs's timezone
+      // plugin uses the host's IANA tzdata to resolve the wall-clock
+      // fields, the same data the prior `Intl.DateTimeFormat`-based
+      // implementation consulted, so the expected strings are
+      // bit-identical between the two implementations on a
+      // Node-official full-ICU runtime.
       const utcAfternoon = Date.UTC(2025, 10, 13, 16, 0, 0, 0);
       assert.strictEqual(dateBucket(utcAfternoon, 'UTC'), '2025-11-13');
       assert.strictEqual(dateBucket(utcAfternoon, 'Asia/Shanghai'), '2025-11-14');
 
-      // UTC 15:59:59.999 on the same day is still 23:59 in Shanghai → same day there.
+      // UTC 15:59:59.999 on the same day is 23:59:59.999 in Shanghai,
+      // still the same Shanghai day.
       const justBeforeShanghaiMidnight = Date.UTC(2025, 10, 13, 15, 59, 59, 999);
       assert.strictEqual(dateBucket(justBeforeShanghaiMidnight, 'Asia/Shanghai'), '2025-11-13');
 
       // A western-hemisphere zone runs the other way.
-      // 2025-11-13T03:00Z is 2025-11-12 19:00 in America/Los_Angeles (PST, UTC-8 in November).
+      // UTC 2025-11-13T03:00 is 2025-11-12 19:00 in America/Los_Angeles
+      // (PST, UTC-8 in November).
       const earlyMorningUtc = Date.UTC(2025, 10, 13, 3, 0, 0, 0);
       assert.strictEqual(dateBucket(earlyMorningUtc, 'America/Los_Angeles'), '2025-11-12');
     });
 
     it('throws RangeError for an unknown IANA timezone', () => {
-      // Intl.DateTimeFormat throws when the timeZone option is unrecognised.
+      // dayjs's timezone plugin delegates the timezone resolution to
+      // `Intl.DateTimeFormat`'s constructor, which throws
+      // `RangeError: Invalid time zone specified` for an unknown IANA
+      // name. The dateBucket function also has an explicit
+      // `dayjsObj.isValid() === false` defense-in-depth check that
+      // would surface its own `RangeError` if dayjs's wrapping ever
+      // caught the Intl exception and returned an invalid-sentinel
+      // dayjs object instead. The user-visible contract — "unknown
+      // zone throws `RangeError`" — is preserved by both layers.
       assert.throws(() => dateBucket(0, 'Not/A_Real_Zone'), RangeError);
+    });
+
+    it('rejects non-finite, non-integer, or negative ms inputs with a RangeError', () => {
+      // The input contract matches the sibling `reverseMs` function in
+      // this same module: a Unix-millisecond timestamp is a finite,
+      // nonnegative integer. The pre-amend implementation would have
+      // passed `NaN` through to `new Date(NaN).toISOString()` which
+      // throws a stdlib `RangeError: Invalid time value` (generic
+      // message, doesn't name `dateBucket`), and `Infinity` through
+      // to the Intl-format path which returned the literal string
+      // `"Invalid Date"` (which then leaks to the OSS key path as a
+      // directory name segment). Both are now caught at the function
+      // boundary with a domain-aware error message that names the
+      // bad input value.
+      assert.throws(() => dateBucket(Number.NaN), RangeError);
+      assert.throws(() => dateBucket(Number.POSITIVE_INFINITY), RangeError);
+      assert.throws(() => dateBucket(Number.NEGATIVE_INFINITY), RangeError);
+      assert.throws(() => dateBucket(1.5), RangeError, 'a fractional ms is out of contract');
+      assert.throws(() => dateBucket(-1), RangeError, 'a pre-epoch negative ms is out of contract');
+      // IEEE-754 signed-zero: `Object.is(-0, 0)` is `false` but
+      // `Number.isInteger(-0)` is `true` and `-0 < 0` is `false`. So
+      // negative-zero passes the `Number.isInteger(ms) && ms >= 0`
+      // guard. Both `Date(0)` and `Date(-0)` represent the Unix
+      // epoch instant, so the function returns the same `'1970-01-01'`
+      // bucket for either input. This is the JavaScript convention
+      // of "the two signed zeros refer to the same value" and we
+      // adopt it here rather than over-specifying the contract.
+      assert.doesNotThrow(() => dateBucket(-0), 'signed -0 collapses to the epoch instant');
+      assert.strictEqual(dateBucket(-0), dateBucket(0));
     });
   });
 });

--- a/core/agent-runtime/test/AgentStoreUtils.test.ts
+++ b/core/agent-runtime/test/AgentStoreUtils.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert';
+
+import { TS_MAX_MS, dateBucket, decodeReverseMs, reverseMs } from '../index';
+
+describe('test/AgentStoreUtils.test.ts', () => {
+  describe('TS_MAX_MS', () => {
+    it('is 9_999_999_999_999 — the algebraic ceiling of a 13-digit ms timestamp', () => {
+      assert.strictEqual(TS_MAX_MS, 9_999_999_999_999);
+      assert.strictEqual(String(TS_MAX_MS).length, 13);
+      // Sanity: this corresponds to a date past the year 2286.
+      const isoOfCeiling = new Date(TS_MAX_MS).toISOString();
+      assert.match(isoOfCeiling, /^2286-/);
+    });
+  });
+
+  describe('reverseMs', () => {
+    it('produces a 13-character zero-padded decimal string', () => {
+      // ms=0 → complement is the max value itself, so the string is all 9s.
+      assert.strictEqual(reverseMs(0), '9999999999999');
+      // ms=TS_MAX_MS → complement is zero, padded to thirteen zeroes.
+      assert.strictEqual(reverseMs(TS_MAX_MS), '0000000000000');
+      // A small positive ms still pads on the left to thirteen chars.
+      assert.strictEqual(reverseMs(1), String(TS_MAX_MS - 1).padStart(13, '0'));
+      assert.strictEqual(reverseMs(1).length, 13);
+    });
+
+    it('matches a known timestamp from the design document', () => {
+      // 2025-11-13T08:00:00.000Z (= 1_763_020_800_000) — pulled from the
+      // worked example in /Users/jerry/.claude/plans/wobbly-swinging-sparkle.md.
+      // The expected complement is 9_999_999_999_999 - 1_763_020_800_000 = 8_236_979_199_999.
+      const knownMs = Date.UTC(2025, 10, 13, 8, 0, 0, 0);
+      assert.strictEqual(knownMs, 1_763_020_800_000);
+      assert.strictEqual(reverseMs(knownMs), '8236979199999');
+    });
+
+    it('throws RangeError for non-integer, negative, or out-of-range ms', () => {
+      assert.throws(() => reverseMs(-1), RangeError);
+      assert.throws(() => reverseMs(TS_MAX_MS + 1), RangeError);
+      assert.throws(() => reverseMs(1.5), RangeError);
+      assert.throws(() => reverseMs(Number.NaN), RangeError);
+      assert.throws(() => reverseMs(Number.POSITIVE_INFINITY), RangeError);
+      assert.throws(() => reverseMs(Number.NEGATIVE_INFINITY), RangeError);
+    });
+
+    it('is strictly monotonically decreasing in lex order versus the input', () => {
+      // Pairs where the first element is strictly less than the second.
+      // Lexicographic comparison on equal-length decimal strings is the same
+      // as numeric comparison; we use the natural String '<'/'>' operators.
+      const pairs: Array<[number, number]> = [
+        [ 0, 1 ],
+        [ 0, TS_MAX_MS ],
+        [ 1, 2 ],
+        [ 1_000, 1_001 ],
+        [ 1_762_992_000_000, 1_763_078_400_000 ], // one day apart in November 2025
+        [ Date.UTC(2025, 0, 1), Date.UTC(2026, 0, 1) ],
+        [ Math.floor(Date.now() / 2), Date.now() ],
+        [ TS_MAX_MS - 1, TS_MAX_MS ],
+      ];
+      for (const [ a, b ] of pairs) {
+        assert.ok(a < b, `precondition: ${a} < ${b}`);
+        const ra = reverseMs(a);
+        const rb = reverseMs(b);
+        assert.strictEqual(ra.length, 13);
+        assert.strictEqual(rb.length, 13);
+        assert.ok(
+          ra > rb,
+          `monotonicity broken for a=${a} b=${b}: reverseMs(a)=${ra} should be > reverseMs(b)=${rb}`,
+        );
+      }
+    });
+  });
+
+  describe('decodeReverseMs', () => {
+    it('inverts reverseMs for a representative range of inputs', () => {
+      const samples = [
+        0,
+        1,
+        999,
+        1_000_000_000_000,
+        Date.UTC(1970, 0, 1, 0, 0, 0, 0),
+        Date.UTC(2025, 10, 13, 8, 0, 1, 234),
+        TS_MAX_MS - 1,
+        TS_MAX_MS,
+      ];
+      for (const ms of samples) {
+        assert.strictEqual(decodeReverseMs(reverseMs(ms)), ms, `round-trip failed for ms=${ms}`);
+      }
+    });
+
+    it('parses the all-zero string as TS_MAX_MS and the all-nine string as zero', () => {
+      assert.strictEqual(decodeReverseMs('0000000000000'), TS_MAX_MS);
+      assert.strictEqual(decodeReverseMs('9999999999999'), 0);
+    });
+
+    it('throws TypeError when the input cannot be parsed as a decimal integer', () => {
+      assert.throws(() => decodeReverseMs('abc'), TypeError);
+      assert.throws(() => decodeReverseMs(''), TypeError);
+      // Leading non-digit text. `parseInt` returns NaN.
+      assert.throws(() => decodeReverseMs('xx0000'), TypeError);
+    });
+  });
+
+  describe('dateBucket', () => {
+    it('defaults to UTC and produces YYYY-MM-DD', () => {
+      assert.strictEqual(dateBucket(0), '1970-01-01');
+      assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 0, 0, 0, 0)), '2025-11-13');
+      assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 12, 34, 56, 789)), '2025-11-13');
+      // Last millisecond of the UTC day stays in that day.
+      assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 23, 59, 59, 999)), '2025-11-13');
+      // Adding one ms crosses the UTC midnight.
+      assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 23, 59, 59, 999) + 1), '2025-11-14');
+    });
+
+    it("treats the 'UTC' string case-insensitively", () => {
+      const t = Date.UTC(2025, 5, 7, 11, 22, 33, 44);
+      assert.strictEqual(dateBucket(t, 'UTC'), dateBucket(t));
+      assert.strictEqual(dateBucket(t, 'utc'), dateBucket(t));
+      assert.strictEqual(dateBucket(t, 'Utc'), dateBucket(t));
+    });
+
+    it('honors a named IANA timezone via Intl.DateTimeFormat', () => {
+      // UTC 16:00 on 2025-11-13 is 2025-11-14T00:00 in Asia/Shanghai (UTC+8, no DST).
+      const utcAfternoon = Date.UTC(2025, 10, 13, 16, 0, 0, 0);
+      assert.strictEqual(dateBucket(utcAfternoon, 'UTC'), '2025-11-13');
+      assert.strictEqual(dateBucket(utcAfternoon, 'Asia/Shanghai'), '2025-11-14');
+
+      // UTC 15:59:59.999 on the same day is still 23:59 in Shanghai → same day there.
+      const justBeforeShanghaiMidnight = Date.UTC(2025, 10, 13, 15, 59, 59, 999);
+      assert.strictEqual(dateBucket(justBeforeShanghaiMidnight, 'Asia/Shanghai'), '2025-11-13');
+
+      // A western-hemisphere zone runs the other way.
+      // 2025-11-13T03:00Z is 2025-11-12 19:00 in America/Los_Angeles (PST, UTC-8 in November).
+      const earlyMorningUtc = Date.UTC(2025, 10, 13, 3, 0, 0, 0);
+      assert.strictEqual(dateBucket(earlyMorningUtc, 'America/Los_Angeles'), '2025-11-12');
+    });
+
+    it('throws RangeError for an unknown IANA timezone', () => {
+      // Intl.DateTimeFormat throws when the timeZone option is unrecognised.
+      assert.throws(() => dateBucket(0, 'Not/A_Real_Zone'), RangeError);
+    });
+  });
+});

--- a/core/agent-runtime/test/AgentStoreUtils.test.ts
+++ b/core/agent-runtime/test/AgentStoreUtils.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import { TS_MAX_MS, dateBucket, decodeReverseMs, reverseMs } from '../index';
+import { TS_MAX_MS, dateBucket, reverseMs } from '../index';
 
 describe('test/AgentStoreUtils.test.ts', () => {
   describe('TS_MAX_MS', () => {
@@ -57,29 +57,6 @@ describe('test/AgentStoreUtils.test.ts', () => {
           `monotonicity broken for a=${a} b=${b}: reverseMs(a)=${ra} should be > reverseMs(b)=${rb}`,
         );
       }
-    });
-  });
-
-  describe('decodeReverseMs', () => {
-    it('inverts reverseMs for a representative range of inputs', () => {
-      const samples = [
-        0,
-        1,
-        999,
-        1_000_000_000_000,
-        Date.UTC(1970, 0, 1, 0, 0, 0, 0),
-        Date.UTC(2025, 10, 13, 8, 0, 1, 234),
-        TS_MAX_MS - 1,
-        TS_MAX_MS,
-      ];
-      for (const ms of samples) {
-        assert.strictEqual(decodeReverseMs(reverseMs(ms)), ms, `round-trip failed for ms=${ms}`);
-      }
-    });
-
-    it('parses the all-zero string as TS_MAX_MS and the all-nine string as zero', () => {
-      assert.strictEqual(decodeReverseMs('0000000000000'), TS_MAX_MS);
-      assert.strictEqual(decodeReverseMs('9999999999999'), 0);
     });
   });
 

--- a/core/agent-runtime/test/AgentStoreUtils.test.ts
+++ b/core/agent-runtime/test/AgentStoreUtils.test.ts
@@ -4,10 +4,9 @@ import { TS_MAX_MS, dateBucket, decodeReverseMs, reverseMs } from '../index';
 
 describe('test/AgentStoreUtils.test.ts', () => {
   describe('TS_MAX_MS', () => {
-    it('is 9_999_999_999_999 — the algebraic ceiling of a 13-digit ms timestamp', () => {
+    it('is the 13-digit millisecond timestamp ceiling', () => {
       assert.strictEqual(TS_MAX_MS, 9_999_999_999_999);
       assert.strictEqual(String(TS_MAX_MS).length, 13);
-      // Sanity: this corresponds to a date past the year 2286.
       const isoOfCeiling = new Date(TS_MAX_MS).toISOString();
       assert.match(isoOfCeiling, /^2286-/);
     });
@@ -15,22 +14,13 @@ describe('test/AgentStoreUtils.test.ts', () => {
 
   describe('reverseMs', () => {
     it('produces a 13-character zero-padded decimal string', () => {
-      // ms=0 → complement is the max value itself, so the string is all 9s.
       assert.strictEqual(reverseMs(0), '9999999999999');
-      // ms=TS_MAX_MS → complement is zero, padded to thirteen zeroes.
       assert.strictEqual(reverseMs(TS_MAX_MS), '0000000000000');
-      // A small positive ms still pads on the left to thirteen chars.
       assert.strictEqual(reverseMs(1), String(TS_MAX_MS - 1).padStart(13, '0'));
       assert.strictEqual(reverseMs(1).length, 13);
     });
 
     it('matches the worked example timestamp from the PR description', () => {
-      // The PR description's worked example uses the instant
-      // 2025-11-13T08:00:00.000Z, which is the Unix-millisecond value
-      // 1_763_020_800_000. The decimal complement against TS_MAX_MS is
-      // 9_999_999_999_999 - 1_763_020_800_000 = 8_236_979_199_999. This
-      // assertion pins the algebra so any drift in the encoding helper
-      // is caught immediately.
       const knownMs = Date.UTC(2025, 10, 13, 8, 0, 0, 0);
       assert.strictEqual(knownMs, 1_763_020_800_000);
       assert.strictEqual(reverseMs(knownMs), '8236979199999');
@@ -46,10 +36,6 @@ describe('test/AgentStoreUtils.test.ts', () => {
     });
 
     it('is strictly monotonically decreasing in lex order versus the input', () => {
-      // Pairs where the first element is strictly less than the second.
-      // Lexicographic comparison on equal-length decimal strings is
-      // identical to numeric comparison, so we use the natural String
-      // `<` / `>` operators.
       const pairs: Array<[number, number]> = [
         [ 0, 1 ],
         [ 0, TS_MAX_MS ],
@@ -98,85 +84,20 @@ describe('test/AgentStoreUtils.test.ts', () => {
   });
 
   describe('dateBucket', () => {
-    it('defaults to UTC and produces YYYY-MM-DD', () => {
+    it('uses UTC and produces YYYY-MM-DD', () => {
       assert.strictEqual(dateBucket(0), '1970-01-01');
       assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 0, 0, 0, 0)), '2025-11-13');
       assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 12, 34, 56, 789)), '2025-11-13');
-      // Last millisecond of the UTC day stays in that day.
       assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 23, 59, 59, 999)), '2025-11-13');
-      // Adding one ms crosses the UTC midnight boundary.
       assert.strictEqual(dateBucket(Date.UTC(2025, 10, 13, 23, 59, 59, 999) + 1), '2025-11-14');
     });
 
-    it("treats the 'UTC' string case-insensitively", () => {
-      const t = Date.UTC(2025, 5, 7, 11, 22, 33, 44);
-      assert.strictEqual(dateBucket(t, 'UTC'), dateBucket(t));
-      assert.strictEqual(dateBucket(t, 'utc'), dateBucket(t));
-      assert.strictEqual(dateBucket(t, 'Utc'), dateBucket(t));
-    });
-
-    it('honors a named IANA timezone (via dayjs\'s timezone plugin under the hood)', () => {
-      // UTC 16:00 on 2025-11-13 is 2025-11-14T00:00 in Asia/Shanghai
-      // (UTC+8, no DST in the Asia/Shanghai zone). dayjs's timezone
-      // plugin uses the host's IANA tzdata to resolve the wall-clock
-      // fields, the same data the prior `Intl.DateTimeFormat`-based
-      // implementation consulted, so the expected strings are
-      // bit-identical between the two implementations on a
-      // Node-official full-ICU runtime.
-      const utcAfternoon = Date.UTC(2025, 10, 13, 16, 0, 0, 0);
-      assert.strictEqual(dateBucket(utcAfternoon, 'UTC'), '2025-11-13');
-      assert.strictEqual(dateBucket(utcAfternoon, 'Asia/Shanghai'), '2025-11-14');
-
-      // UTC 15:59:59.999 on the same day is 23:59:59.999 in Shanghai,
-      // still the same Shanghai day.
-      const justBeforeShanghaiMidnight = Date.UTC(2025, 10, 13, 15, 59, 59, 999);
-      assert.strictEqual(dateBucket(justBeforeShanghaiMidnight, 'Asia/Shanghai'), '2025-11-13');
-
-      // A western-hemisphere zone runs the other way.
-      // UTC 2025-11-13T03:00 is 2025-11-12 19:00 in America/Los_Angeles
-      // (PST, UTC-8 in November).
-      const earlyMorningUtc = Date.UTC(2025, 10, 13, 3, 0, 0, 0);
-      assert.strictEqual(dateBucket(earlyMorningUtc, 'America/Los_Angeles'), '2025-11-12');
-    });
-
-    it('throws RangeError for an unknown IANA timezone', () => {
-      // dayjs's timezone plugin delegates the timezone resolution to
-      // `Intl.DateTimeFormat`'s constructor, which throws
-      // `RangeError: Invalid time zone specified` for an unknown IANA
-      // name. The dateBucket function also has an explicit
-      // `dayjsObj.isValid() === false` defense-in-depth check that
-      // would surface its own `RangeError` if dayjs's wrapping ever
-      // caught the Intl exception and returned an invalid-sentinel
-      // dayjs object instead. The user-visible contract — "unknown
-      // zone throws `RangeError`" — is preserved by both layers.
-      assert.throws(() => dateBucket(0, 'Not/A_Real_Zone'), RangeError);
-    });
-
     it('rejects non-finite, non-integer, or negative ms inputs with a RangeError', () => {
-      // The input contract matches the sibling `reverseMs` function in
-      // this same module: a Unix-millisecond timestamp is a finite,
-      // nonnegative integer. The pre-amend implementation would have
-      // passed `NaN` through to `new Date(NaN).toISOString()` which
-      // throws a stdlib `RangeError: Invalid time value` (generic
-      // message, doesn't name `dateBucket`), and `Infinity` through
-      // to the Intl-format path which returned the literal string
-      // `"Invalid Date"` (which then leaks to the OSS key path as a
-      // directory name segment). Both are now caught at the function
-      // boundary with a domain-aware error message that names the
-      // bad input value.
       assert.throws(() => dateBucket(Number.NaN), RangeError);
       assert.throws(() => dateBucket(Number.POSITIVE_INFINITY), RangeError);
       assert.throws(() => dateBucket(Number.NEGATIVE_INFINITY), RangeError);
       assert.throws(() => dateBucket(1.5), RangeError, 'a fractional ms is out of contract');
       assert.throws(() => dateBucket(-1), RangeError, 'a pre-epoch negative ms is out of contract');
-      // IEEE-754 signed-zero: `Object.is(-0, 0)` is `false` but
-      // `Number.isInteger(-0)` is `true` and `-0 < 0` is `false`. So
-      // negative-zero passes the `Number.isInteger(ms) && ms >= 0`
-      // guard. Both `Date(0)` and `Date(-0)` represent the Unix
-      // epoch instant, so the function returns the same `'1970-01-01'`
-      // bucket for either input. This is the JavaScript convention
-      // of "the two signed zeros refer to the same value" and we
-      // adopt it here rather than over-specifying the contract.
       assert.doesNotThrow(() => dateBucket(-0), 'signed -0 collapses to the epoch instant');
       assert.strictEqual(dateBucket(-0), dateBucket(0));
     });

--- a/core/agent-runtime/test/OSSAgentStore.test.ts
+++ b/core/agent-runtime/test/OSSAgentStore.test.ts
@@ -562,7 +562,27 @@ describe('test/OSSAgentStore.test.ts', () => {
       );
       assert.equal(call[1], thread.id);
       assert.match(call[2] as string, /^agent\/index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_/);
-      assert.match(call[3] as string, /simulated PUT failure/);
+      // The fourth post-format argument is the underlying `Error`
+      // instance, passed verbatim by the catch handler so that the
+      // logger's `util.format`-style trailing-arg `util.inspect`
+      // rendering preserves the stack trace. `assert.match` requires
+      // a string, so we destructure the `.message` field for the
+      // text-shape assertion and `instanceof Error` for the
+      // type-shape assertion.
+      const errArg = call[3];
+      assert.ok(
+        errArg instanceof Error,
+        `expected the fourth warn-arg to be an Error instance (so the stack is preserved when the logger renders it), got ${typeof errArg}: ${String(errArg)}`,
+      );
+      assert.match((errArg as Error).message, /simulated PUT failure/);
+      // The format string itself no longer carries a trailing
+      // `err=%s` placeholder because the Error is the unformatted
+      // trailing arg consumed by `util.format`'s
+      // `util.inspect`-on-the-tail-args rule, not a `%s` slot.
+      assert.ok(
+        !(call[0] as string).includes('err=%s'),
+        'the format string should no longer carry an err=%s placeholder',
+      );
 
       // And the read path keeps working — getThread does not consult the index.
       const fetched = await localStore.getThread(thread.id);
@@ -642,6 +662,82 @@ describe('test/OSSAgentStore.test.ts', () => {
       // And the timer wasn't somehow optimised away — destroy was reached
       // after the createThread call (sanity check on the captured timestamps).
       assert.ok(clientDestroyCalledAt >= createReturnedAt);
+    });
+
+    it('destroy() drains a write that arrives during a previous drain iteration', async () => {
+      // This is the precise scenario the `while`-loop drain in
+      // `awaitPendingWrites` guards against: a `createThread` call
+      // lands while `destroy()` is already in the middle of an
+      // `await Promise.allSettled([...this.pendingIndexWrites])` for
+      // the first batch of in-flight writes. The first
+      // `Promise.allSettled`'s snapshot was taken at the moment
+      // `destroy()` started — the late-arriving createThread's
+      // background-PUT promise is added to the Set *after* that
+      // snapshot, so a one-shot drain (without the surrounding
+      // `while`-loop) would miss it and let `destroy()` return
+      // before the second PUT had settled. The loop notices the Set
+      // is still non-empty after the first iteration's `allSettled`
+      // resolves (the late entry's the only one left), takes a
+      // fresh snapshot, and waits on the late arrival too.
+      //
+      // The test engineers the timing window by holding the
+      // destroy-promise without awaiting it, then firing a second
+      // `createThread`. The microtask discipline guarantees the
+      // second createThread's body runs and adds its background-PUT
+      // promise to the Set before the first iteration's
+      // `Promise.allSettled` resolves, since the first PUT's
+      // artificial delay is large compared to the time it takes for
+      // the second createThread's synchronous-up-to-the-first-await
+      // body to enqueue its own background PUT.
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const INDEX_DELAY_MS = 80;
+      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-date\//, INDEX_DELAY_MS);
+
+      const thread1 = await localStore.createThread({ ordinal: 1 });
+      assert.equal(
+        client.keysWithPrefix('agent/index/threads-by-date/').length,
+        0,
+        'thread1\'s index PUT should still be in flight at this instant',
+      );
+
+      // Hold the destroy-promise without awaiting yet, so the test
+      // code can interleave a second createThread between the
+      // start of the drain and its first `Promise.allSettled`
+      // settling.
+      const destroyP = localStore.destroy();
+
+      // The second createThread runs its synchronous prelude (meta
+      // PUT, which the in-memory MapStorageClient resolves on the
+      // next microtask), then synchronously kicks off the second
+      // background index PUT and adds it to the in-flight Set.
+      // Because the in-memory meta PUT is microtask-fast and the
+      // first thread's index PUT is on an 80 ms setTimeout, the
+      // Set has both entries by the time the test awaits the
+      // second createThread's returned ThreadRecord.
+      const thread2 = await localStore.createThread({ ordinal: 2 });
+
+      // Now wait for destroy() to finish. The destroy's
+      // awaitPendingWrites loop sees the Set is still non-empty
+      // after the first `Promise.allSettled` resolves (thread2's
+      // PUT is on its own timer that's a few ms behind thread1's),
+      // takes a fresh snapshot, and waits on the second PUT.
+      await destroyP;
+
+      // Both index entries are present in the in-memory map.
+      const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/');
+      assert.equal(
+        indexKeys.length,
+        2,
+        `the drain loop should have captured both the original and the late-arriving index write, got ${JSON.stringify(indexKeys)}`,
+      );
+      const threadIdsInLexOrder = indexKeys.map(k => {
+        const fileName = k.slice(k.lastIndexOf('/') + 1);
+        return fileName.slice(fileName.indexOf('_') + 1);
+      }).sort();
+      const expectedIds = [ thread1.id, thread2.id ].sort();
+      assert.deepStrictEqual(threadIdsInLexOrder, expectedIds);
     });
 
     it('awaitPendingWrites() is a no-op resolved promise when there are no pending writes', async () => {

--- a/core/agent-runtime/test/OSSAgentStore.test.ts
+++ b/core/agent-runtime/test/OSSAgentStore.test.ts
@@ -298,7 +298,7 @@ describe('test/OSSAgentStore.test.ts', () => {
     });
   });
 
-  describe('thread time index', () => {
+  describe('thread activity index', () => {
     function withFixedNow<T>(ms: number, fn: () => Promise<T>): Promise<T> {
       const realNow = Date.now;
       Date.now = () => ms;
@@ -309,14 +309,14 @@ describe('test/OSSAgentStore.test.ts', () => {
         });
     }
 
-    const INDEX_KEY_RE_AGENT = /^agent\/index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_[0-9a-f-]+$/;
-    const INDEX_KEY_RE_ANY = /^(?:[^/]+(?:\/[^/]+)*\/)?index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_[0-9a-f-]+$/;
+    const INDEX_KEY_RE_AGENT = /^agent\/index\/threads-by-updated-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_[0-9a-f-]+$/;
+    const INDEX_KEY_RE_ANY = /^(?:[^/]+(?:\/[^/]+)*\/)?index\/threads-by-updated-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_[0-9a-f-]+$/;
 
     const T_EARLY = Date.UTC(2025, 10, 13, 8, 0, 0, 0);
     const T_MID = Date.UTC(2025, 10, 13, 8, 0, 1, 234);
     const T_LATE = Date.UTC(2025, 10, 13, 10, 0, 0, 0);
 
-    it('writes a sidecar time index next to meta.json on createThread', async () => {
+    it('writes a sidecar activity index next to meta.json on createThread', async () => {
       const client = new MapStorageClient();
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
@@ -329,17 +329,17 @@ describe('test/OSSAgentStore.test.ts', () => {
         `meta.json not found amongst keys: ${JSON.stringify(keys)}`,
       );
 
-      const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/');
+      const indexKeys = client.keysWithPrefix('agent/index/threads-by-updated-date/');
       assert.equal(indexKeys.length, 1, `expected exactly one index entry, got ${JSON.stringify(indexKeys)}`);
       const indexKey = indexKeys[0];
       assert.match(indexKey, INDEX_KEY_RE_AGENT);
 
       const expectedRev = reverseMs(T_MID);
-      const expectedKey = `agent/index/threads-by-date/2025-11-13/${expectedRev}_${thread.id}`;
+      const expectedKey = `agent/index/threads-by-updated-date/2025-11-13/${expectedRev}_${thread.id}`;
       assert.equal(indexKey, expectedKey);
     });
 
-    it('the index body carries threadId, Unix-second createdAt and a snapshot of metadata', async () => {
+    it('the index body carries threadId, createdAt, updatedAt and a snapshot of metadata', async () => {
       const client = new MapStorageClient();
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
       const meta: Record<string, unknown> = { user: 'alice', channel: 'web' };
@@ -347,24 +347,31 @@ describe('test/OSSAgentStore.test.ts', () => {
       const thread = await withFixedNow(T_MID, () => localStore.createThread(meta));
       await localStore.awaitPendingWrites();
 
-      const indexKey = client.keysWithPrefix('agent/index/threads-by-date/')[0];
+      const indexKey = client.keysWithPrefix('agent/index/threads-by-updated-date/')[0];
       const raw = await client.get(indexKey);
       assert.ok(raw, 'index body should be present after drain');
-      const body = JSON.parse(raw) as { threadId: string; createdAt: number; metadata: Record<string, unknown> };
+      const body = JSON.parse(raw) as {
+        threadId: string;
+        createdAt: number;
+        updatedAt: number;
+        metadata: Record<string, unknown>;
+      };
 
       assert.deepStrictEqual(body, {
         threadId: thread.id,
         createdAt: Math.floor(T_MID / 1000),
+        updatedAt: Math.floor(T_MID / 1000),
         metadata: { user: 'alice', channel: 'web' },
       });
       assert.strictEqual(body.createdAt, thread.createdAt);
+      assert.strictEqual(body.updatedAt, thread.createdAt);
 
       meta.user = 'mutated';
       const reread = JSON.parse((await client.get(indexKey))!) as typeof body;
       assert.equal(reread.metadata.user, 'alice');
     });
 
-    it('within a date directory, ASC dictionary order equals time-DESC creation order', async () => {
+    it('within a date directory, ASC dictionary order equals time-DESC activity order', async () => {
       const client = new MapStorageClient();
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
@@ -373,7 +380,7 @@ describe('test/OSSAgentStore.test.ts', () => {
       const late = await withFixedNow(T_LATE, () => localStore.createThread({ tag: 'late' }));
       await localStore.awaitPendingWrites();
 
-      const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/2025-11-13/');
+      const indexKeys = client.keysWithPrefix('agent/index/threads-by-updated-date/2025-11-13/');
       assert.equal(indexKeys.length, 3);
 
       const threadIdsInListOrder = indexKeys.map(k => {
@@ -390,7 +397,7 @@ describe('test/OSSAgentStore.test.ts', () => {
       assert.ok(revs[0] < revs[1] && revs[1] < revs[2], 'revs must be ASCII-ascending');
     });
 
-    it('threads created on either side of a UTC day boundary land in different date buckets', async () => {
+    it('threads active on either side of a UTC day boundary land in different date buckets', async () => {
       const client = new MapStorageClient();
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
@@ -401,8 +408,8 @@ describe('test/OSSAgentStore.test.ts', () => {
       const later = await withFixedNow(firstMsOfNov14Utc, () => localStore.createThread());
       await localStore.awaitPendingWrites();
 
-      const nov13 = client.keysWithPrefix('agent/index/threads-by-date/2025-11-13/');
-      const nov14 = client.keysWithPrefix('agent/index/threads-by-date/2025-11-14/');
+      const nov13 = client.keysWithPrefix('agent/index/threads-by-updated-date/2025-11-13/');
+      const nov14 = client.keysWithPrefix('agent/index/threads-by-updated-date/2025-11-14/');
       assert.equal(nov13.length, 1, `Nov 13 bucket: ${JSON.stringify(nov13)}`);
       assert.equal(nov14.length, 1, `Nov 14 bucket: ${JSON.stringify(nov14)}`);
       assert.ok(nov13[0].endsWith(`_${earlier.id}`));
@@ -414,7 +421,7 @@ describe('test/OSSAgentStore.test.ts', () => {
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
       const INDEX_DELAY_MS = 120;
-      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-date\//, INDEX_DELAY_MS);
+      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-updated-date\//, INDEX_DELAY_MS);
 
       const t0 = Date.now();
       const thread = await localStore.createThread();
@@ -434,14 +441,14 @@ describe('test/OSSAgentStore.test.ts', () => {
       assert.ok(await client.get(`agent/threads/${thread.id}/meta.json`));
 
       await localStore.awaitPendingWrites();
-      const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/');
+      const indexKeys = client.keysWithPrefix('agent/index/threads-by-updated-date/');
       assert.equal(indexKeys.length, 1);
       assert.ok(indexKeys[0].endsWith(`_${thread.id}`));
     });
 
     it('createThread succeeds even when the index PUT throws; the failure becomes a single warn line', async () => {
       const client = new MapStorageClient();
-      client.failPutWhenKeyMatches(/^agent\/index\/threads-by-date\//);
+      client.failPutWhenKeyMatches(/^agent\/index\/threads-by-updated-date\//);
 
       const warnCalls: unknown[][] = [];
       const logger = {
@@ -478,11 +485,11 @@ describe('test/OSSAgentStore.test.ts', () => {
       const formatStr = call[0];
       assert.equal(typeof formatStr, 'string');
       assert.ok(
-        (formatStr as string).includes('failed to write thread time index'),
+        (formatStr as string).includes('failed to write thread activity index'),
         `unexpected warn format string: ${String(formatStr)}`,
       );
       assert.equal(call[1], thread.id);
-      assert.match(call[2] as string, /^agent\/index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_/);
+      assert.match(call[2] as string, /^agent\/index\/threads-by-updated-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_/);
       const errArg = call[3];
       assert.ok(
         errArg instanceof Error,
@@ -500,7 +507,7 @@ describe('test/OSSAgentStore.test.ts', () => {
 
     it('with no logger configured, an index PUT failure falls back to console.warn without throwing', async () => {
       const client = new MapStorageClient();
-      client.failPutWhenKeyMatches(/^agent\/index\/threads-by-date\//);
+      client.failPutWhenKeyMatches(/^agent\/index\/threads-by-updated-date\//);
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
       const realWarn = console.warn;
@@ -515,7 +522,7 @@ describe('test/OSSAgentStore.test.ts', () => {
         assert.equal(captured.length, 1);
         const args = captured[0];
         assert.equal(typeof args[0], 'string');
-        assert.ok((args[0] as string).includes('failed to write thread time index'));
+        assert.ok((args[0] as string).includes('failed to write thread activity index'));
         assert.equal(args[1], thread.id);
       } finally {
         console.warn = realWarn;
@@ -527,7 +534,7 @@ describe('test/OSSAgentStore.test.ts', () => {
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
       const INDEX_DELAY_MS = 120;
-      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-date\//, INDEX_DELAY_MS);
+      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-updated-date\//, INDEX_DELAY_MS);
 
       let clientDestroyCalledAt: number | null = null;
       let indexKeyVisibleAtDestroy = false;
@@ -555,7 +562,7 @@ describe('test/OSSAgentStore.test.ts', () => {
         'the index entry should have been observable to client.destroy, meaning the drain ran first',
       );
 
-      assert.equal(client.keysWithPrefix('agent/index/threads-by-date/').length, 1);
+      assert.equal(client.keysWithPrefix('agent/index/threads-by-updated-date/').length, 1);
       assert.ok(clientDestroyCalledAt >= createReturnedAt);
     });
 
@@ -564,11 +571,11 @@ describe('test/OSSAgentStore.test.ts', () => {
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
       const INDEX_DELAY_MS = 80;
-      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-date\//, INDEX_DELAY_MS);
+      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-updated-date\//, INDEX_DELAY_MS);
 
       const thread1 = await localStore.createThread({ ordinal: 1 });
       assert.equal(
-        client.keysWithPrefix('agent/index/threads-by-date/').length,
+        client.keysWithPrefix('agent/index/threads-by-updated-date/').length,
         0,
         'thread1\'s index PUT should still be in flight at this instant',
       );
@@ -577,7 +584,7 @@ describe('test/OSSAgentStore.test.ts', () => {
       const thread2 = await localStore.createThread({ ordinal: 2 });
       await destroyP;
 
-      const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/');
+      const indexKeys = client.keysWithPrefix('agent/index/threads-by-updated-date/');
       assert.equal(
         indexKeys.length,
         2,
@@ -612,7 +619,7 @@ describe('test/OSSAgentStore.test.ts', () => {
       const bareStore = new OSSAgentStore({ client: bareClient });
       await withFixedNow(T_MID, () => bareStore.createThread());
       await bareStore.awaitPendingWrites();
-      const bareIndex = bareClient.keysWithPrefix('index/threads-by-date/');
+      const bareIndex = bareClient.keysWithPrefix('index/threads-by-updated-date/');
       assert.equal(bareIndex.length, 1);
       assert.ok(!bareIndex[0].startsWith('/'), `expected no leading "/", got ${bareIndex[0]}`);
       assert.match(bareIndex[0], INDEX_KEY_RE_ANY);
@@ -621,9 +628,9 @@ describe('test/OSSAgentStore.test.ts', () => {
       const nestedStore = new OSSAgentStore({ client: nestedClient, prefix: 'a/b' });
       await withFixedNow(T_MID, () => nestedStore.createThread());
       await nestedStore.awaitPendingWrites();
-      const nestedIndex = nestedClient.keysWithPrefix('a/b/index/threads-by-date/');
+      const nestedIndex = nestedClient.keysWithPrefix('a/b/index/threads-by-updated-date/');
       assert.equal(nestedIndex.length, 1, `expected exactly one nested index entry: ${JSON.stringify(nestedClient.keys())}`);
-      assert.match(nestedIndex[0], /^a\/b\/index\/threads-by-date\/2025-11-13\/\d{13}_thread_[0-9a-f-]+$/);
+      assert.match(nestedIndex[0], /^a\/b\/index\/threads-by-updated-date\/2025-11-13\/\d{13}_thread_[0-9a-f-]+$/);
 
       const metaKey = nestedClient.keys().find(k => k.startsWith('a/b/threads/') && k.endsWith('/meta.json'));
       assert.ok(metaKey, 'meta.json key for the nested prefix should exist');
@@ -631,15 +638,14 @@ describe('test/OSSAgentStore.test.ts', () => {
       assert.ok(nestedIndex[0].endsWith(`_${expectedThreadId}`));
     });
 
-    it('appendMessages, createRun, and updateRun never touch the time index after createThread', async () => {
+    it('appendMessages writes a new activity index entry for a reused historical thread', async () => {
       const client = new MapStorageClient();
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
-      const thread = await localStore.createThread({ origin: 'audit' });
+      const createdMs = Date.UTC(2025, 10, 13, 8, 0, 0, 0);
+      const updatedMs = Date.UTC(2025, 10, 14, 9, 0, 0, 0);
+      const thread = await withFixedNow(createdMs, () => localStore.createThread({ origin: 'audit' }));
       await localStore.awaitPendingWrites();
-      const indexKeysBefore = client.keysWithPrefix('agent/index/').slice();
-      const indexBodyBefore = await client.get(indexKeysBefore[0]);
-      assert.equal(indexKeysBefore.length, 1, 'baseline: exactly one index entry from createThread');
 
       const messages: AgentMessage[] = [
         { type: 'user', message: { role: 'user', content: 'hello' } } as unknown as AgentMessage,
@@ -648,7 +654,39 @@ describe('test/OSSAgentStore.test.ts', () => {
           message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
         } as unknown as AgentMessage,
       ];
-      await localStore.appendMessages(thread.id, messages);
+      await withFixedNow(updatedMs, () => localStore.appendMessages(thread.id, messages));
+      await localStore.awaitPendingWrites();
+
+      const createdDay = client.keysWithPrefix('agent/index/threads-by-updated-date/2025-11-13/');
+      const updatedDay = client.keysWithPrefix('agent/index/threads-by-updated-date/2025-11-14/');
+      assert.equal(createdDay.length, 1, `created-day index: ${JSON.stringify(createdDay)}`);
+      assert.equal(updatedDay.length, 1, `updated-day index: ${JSON.stringify(updatedDay)}`);
+      assert.ok(createdDay[0].endsWith(`_${thread.id}`));
+      assert.ok(updatedDay[0].endsWith(`_${thread.id}`));
+
+      const updatedBody = JSON.parse((await client.get(updatedDay[0]))!) as {
+        threadId: string;
+        createdAt: number;
+        updatedAt: number;
+        metadata: Record<string, unknown>;
+      };
+      assert.deepStrictEqual(updatedBody, {
+        threadId: thread.id,
+        createdAt: Math.floor(createdMs / 1000),
+        updatedAt: Math.floor(updatedMs / 1000),
+        metadata: { origin: 'audit' },
+      });
+    });
+
+    it('createRun and updateRun never touch the activity index', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const thread = await localStore.createThread({ origin: 'audit' });
+      await localStore.awaitPendingWrites();
+      const indexKeysBefore = client.keysWithPrefix('agent/index/').slice();
+      const indexBodyBefore = await client.get(indexKeysBefore[0]);
+      assert.equal(indexKeysBefore.length, 1, 'baseline: exactly one index entry from createThread');
 
       const run = await localStore.createRun(
         [{ role: 'user', content: 'first turn' }],
@@ -665,7 +703,7 @@ describe('test/OSSAgentStore.test.ts', () => {
       assert.deepStrictEqual(
         indexKeysAfter.slice().sort(),
         indexKeysBefore.slice().sort(),
-        'no new index keys should appear; the index entry is the immutable thread-birth record',
+        'no new index keys should appear from run operations',
       );
       const indexBodyAfter = await client.get(indexKeysAfter[0]);
       assert.equal(indexBodyAfter, indexBodyBefore, 'the index body should be byte-identical');

--- a/core/agent-runtime/test/OSSAgentStore.test.ts
+++ b/core/agent-runtime/test/OSSAgentStore.test.ts
@@ -301,8 +301,6 @@ describe('test/OSSAgentStore.test.ts', () => {
   });
 
   describe('thread time index', () => {
-    // Drive Date.now() to a fixed millisecond value for the duration of `fn`,
-    // then restore the real clock — used so we can predict the index key bytes.
     function withFixedNow<T>(ms: number, fn: () => Promise<T>): Promise<T> {
       const realNow = Date.now;
       Date.now = () => ms;
@@ -313,17 +311,12 @@ describe('test/OSSAgentStore.test.ts', () => {
         });
     }
 
-    // The shape every fully-prefixed (`agent/`) time-index key should match:
-    // `agent/index/threads-by-date/<YYYY-MM-DD>/<13-digit-revMs>_<thread_<uuid>>`.
     const INDEX_KEY_RE_AGENT = /^agent\/index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_[0-9a-f-]+$/;
-    // Same shape but allowing any prefix segment (including the empty prefix).
     const INDEX_KEY_RE_ANY = /^(?:[^/]+(?:\/[^/]+)*\/)?index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_[0-9a-f-]+$/;
 
-    // Three sample wall-clock instants we use repeatedly. All Date.UTC arguments
-    // are zero-indexed in the month slot (so 10 means November).
-    const T_EARLY = Date.UTC(2025, 10, 13, 8, 0, 0, 0); //  2025-11-13T08:00:00.000Z = 1763020800000 ms
-    const T_MID = Date.UTC(2025, 10, 13, 8, 0, 1, 234); //  2025-11-13T08:00:01.234Z = 1763020801234 ms
-    const T_LATE = Date.UTC(2025, 10, 13, 10, 0, 0, 0); //  2025-11-13T10:00:00.000Z = 1763028000000 ms
+    const T_EARLY = Date.UTC(2025, 10, 13, 8, 0, 0, 0);
+    const T_MID = Date.UTC(2025, 10, 13, 8, 0, 1, 234);
+    const T_LATE = Date.UTC(2025, 10, 13, 10, 0, 0, 0);
 
     it('writes a sidecar time index next to meta.json on createThread', async () => {
       const client = new MapStorageClient();
@@ -347,11 +340,9 @@ describe('test/OSSAgentStore.test.ts', () => {
       const expectedKey = `agent/index/threads-by-date/2025-11-13/${expectedRev}_${thread.id}`;
       assert.equal(indexKey, expectedKey);
 
-      // The suffix is a faithful encoding: decoding it recovers the original ms.
       const fileName = indexKey.slice(indexKey.lastIndexOf('/') + 1);
       const decoded = decodeReverseMs(fileName.slice(0, fileName.indexOf('_')));
       assert.equal(decoded, T_MID);
-      // TS_MAX_MS export is the operand the encoder used.
       assert.equal(parseInt(fileName.slice(0, fileName.indexOf('_')), 10), TS_MAX_MS - T_MID);
     });
 
@@ -373,13 +364,8 @@ describe('test/OSSAgentStore.test.ts', () => {
         createdAt: Math.floor(T_MID / 1000),
         metadata: { user: 'alice', channel: 'web' },
       });
-      // The body's createdAt is the same Unix-second value as the thread record's,
-      // because both derive from a single Date.now() reading.
       assert.strictEqual(body.createdAt, thread.createdAt);
 
-      // The body is a JSON snapshot taken at write time — mutating the original
-      // metadata object after the fact must not be reflected in the persisted
-      // body, since the OSSAgentStore wrote a serialized copy.
       meta.user = 'mutated';
       const reread = JSON.parse((await client.get(indexKey))!) as typeof body;
       assert.equal(reread.metadata.user, 'alice');
@@ -394,8 +380,6 @@ describe('test/OSSAgentStore.test.ts', () => {
       const late = await withFixedNow(T_LATE, () => localStore.createThread({ tag: 'late' }));
       await localStore.awaitPendingWrites();
 
-      // keysWithPrefix returns the array already sorted ASCII-ascending, which
-      // is also how an OSS ListObjects would return the keys.
       const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/2025-11-13/');
       assert.equal(indexKeys.length, 3);
 
@@ -403,7 +387,6 @@ describe('test/OSSAgentStore.test.ts', () => {
         const fileName = k.slice(k.lastIndexOf('/') + 1);
         return fileName.slice(fileName.indexOf('_') + 1);
       });
-      // Newest first because the suffix is the time complement.
       assert.deepStrictEqual(threadIdsInListOrder, [ late.id, mid.id, early.id ]);
 
       const revs = indexKeys.map(k => {
@@ -433,45 +416,6 @@ describe('test/OSSAgentStore.test.ts', () => {
       assert.ok(nov14[0].endsWith(`_${later.id}`));
     });
 
-    it('honors the dateTimezone option when picking the day bucket', async () => {
-      // UTC 18:00 maps to next-day 02:00 in Asia/Shanghai (UTC+8, no DST).
-      const physicalMs = Date.UTC(2025, 10, 13, 18, 0, 0, 0);
-
-      const shanghaiClient = new MapStorageClient();
-      const shanghaiStore = new OSSAgentStore({
-        client: shanghaiClient,
-        prefix: 'agent/',
-        dateTimezone: 'Asia/Shanghai',
-      });
-      await withFixedNow(physicalMs, () => shanghaiStore.createThread());
-      await shanghaiStore.awaitPendingWrites();
-
-      assert.equal(
-        shanghaiClient.keysWithPrefix('agent/index/threads-by-date/2025-11-14/').length,
-        1,
-        'Shanghai store should bucket UTC 18:00 into the +08 next-day directory',
-      );
-      assert.equal(
-        shanghaiClient.keysWithPrefix('agent/index/threads-by-date/2025-11-13/').length,
-        0,
-      );
-
-      const utcClient = new MapStorageClient();
-      const utcStore = new OSSAgentStore({ client: utcClient, prefix: 'agent/' });
-      await withFixedNow(physicalMs, () => utcStore.createThread());
-      await utcStore.awaitPendingWrites();
-
-      assert.equal(
-        utcClient.keysWithPrefix('agent/index/threads-by-date/2025-11-13/').length,
-        1,
-        'Default-UTC store should bucket the same instant into the same-day UTC directory',
-      );
-      assert.equal(
-        utcClient.keysWithPrefix('agent/index/threads-by-date/2025-11-14/').length,
-        0,
-      );
-    });
-
     it('createThread does not wait for the index PUT to complete (non-blocking)', async () => {
       const client = new MapStorageClient();
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
@@ -483,28 +427,19 @@ describe('test/OSSAgentStore.test.ts', () => {
       const thread = await localStore.createThread();
       const elapsedMs = Date.now() - t0;
 
-      // The meta.json PUT against an in-memory Map resolves on the next
-      // microtask, so any latency over ~10 ms here would indicate that the
-      // 120 ms artificial delay on the *index* key wormed its way onto the
-      // caller's await chain. A generous bound of (DELAY - 50) ms keeps the
-      // assertion robust against scheduling jitter on shared CI without
-      // making the assertion vacuous.
       assert.ok(
         elapsedMs < INDEX_DELAY_MS - 50,
         `createThread should return before the index PUT settles, but elapsed=${elapsedMs}ms (delay=${INDEX_DELAY_MS}ms)`,
       );
 
-      // At this exact instant the index key is not yet visible.
       assert.equal(
         client.keysWithPrefix('agent/index/').length,
         0,
         'the slow background PUT should not be visible at the moment createThread returns',
       );
 
-      // The meta.json is, however, already on disk.
       assert.ok(await client.get(`agent/threads/${thread.id}/meta.json`));
 
-      // After we explicitly drain the queue, the index does land.
       await localStore.awaitPendingWrites();
       const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/');
       assert.equal(indexKeys.length, 1);
@@ -527,31 +462,24 @@ describe('test/OSSAgentStore.test.ts', () => {
         logger,
       });
 
-      // createThread itself resolves cleanly. The injected put failure for
-      // the index key is observed only as a warn line.
       const thread = await localStore.createThread({ trace: 'fail-path' });
       assert.equal(thread.object, 'thread');
       assert.match(thread.id, /^thread_[0-9a-f-]{36}$/);
 
-      // awaitPendingWrites should also not throw — `Promise.allSettled` swallows
-      // the rejection that the catch handler converted into a warn.
       await localStore.awaitPendingWrites();
 
-      // Main data is intact.
       const metaRaw = await client.get(`agent/threads/${thread.id}/meta.json`);
       assert.ok(metaRaw, 'meta.json should still be present when only the index PUT failed');
       const metaObj = JSON.parse(metaRaw) as { id: string; createdAt: number };
       assert.equal(metaObj.id, thread.id);
       assert.equal(metaObj.createdAt, thread.createdAt);
 
-      // No index objects were written.
       assert.equal(
         client.keysWithPrefix('agent/index/').length,
         0,
         'the simulated index PUT failure means no index entries exist',
       );
 
-      // Exactly one warn invocation, carrying threadId / indexKey / errMessage as the trailing args.
       assert.equal(warnCalls.length, 1, `expected one warn call, got ${warnCalls.length}: ${JSON.stringify(warnCalls)}`);
       const call = warnCalls[0];
       const formatStr = call[0];
@@ -562,29 +490,17 @@ describe('test/OSSAgentStore.test.ts', () => {
       );
       assert.equal(call[1], thread.id);
       assert.match(call[2] as string, /^agent\/index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_/);
-      // The fourth post-format argument is the underlying `Error`
-      // instance, passed verbatim by the catch handler so that the
-      // logger's `util.format`-style trailing-arg `util.inspect`
-      // rendering preserves the stack trace. `assert.match` requires
-      // a string, so we destructure the `.message` field for the
-      // text-shape assertion and `instanceof Error` for the
-      // type-shape assertion.
       const errArg = call[3];
       assert.ok(
         errArg instanceof Error,
         `expected the fourth warn-arg to be an Error instance (so the stack is preserved when the logger renders it), got ${typeof errArg}: ${String(errArg)}`,
       );
       assert.match((errArg as Error).message, /simulated PUT failure/);
-      // The format string itself no longer carries a trailing
-      // `err=%s` placeholder because the Error is the unformatted
-      // trailing arg consumed by `util.format`'s
-      // `util.inspect`-on-the-tail-args rule, not a `%s` slot.
       assert.ok(
         !(call[0] as string).includes('err=%s'),
         'the format string should no longer carry an err=%s placeholder',
       );
 
-      // And the read path keeps working — getThread does not consult the index.
       const fetched = await localStore.getThread(thread.id);
       assert.equal(fetched.id, thread.id);
     });
@@ -594,7 +510,6 @@ describe('test/OSSAgentStore.test.ts', () => {
       client.failPutWhenKeyMatches(/^agent\/index\/threads-by-date\//);
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
-      // Intercept console.warn so the suite stays quiet and we can confirm the fallback wired up.
       const realWarn = console.warn;
       const captured: unknown[][] = [];
       console.warn = ((...args: unknown[]) => {
@@ -621,9 +536,6 @@ describe('test/OSSAgentStore.test.ts', () => {
       const INDEX_DELAY_MS = 120;
       client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-date\//, INDEX_DELAY_MS);
 
-      // Capture the moment the underlying client's destroy gets called, so we
-      // can sequence "drain finishes, then client.destroy fires". The base
-      // MapStorageClient has no destroy method, so we attach one for this test.
       let clientDestroyCalledAt: number | null = null;
       let indexKeyVisibleAtDestroy = false;
       client.destroy = async () => {
@@ -633,62 +545,28 @@ describe('test/OSSAgentStore.test.ts', () => {
 
       const createReturnedAt = Date.now();
       await localStore.createThread();
-      // The slow PUT is still in flight.
       assert.equal(client.keysWithPrefix('agent/index/').length, 0);
 
       const beforeDestroy = Date.now();
       await localStore.destroy();
       const elapsedMs = Date.now() - beforeDestroy;
 
-      // destroy waited for the 120 ms PUT to settle. Allow a small (10 ms)
-      // tolerance window in case of sub-millisecond timer skew.
       assert.ok(
         elapsedMs >= INDEX_DELAY_MS - 20,
         `destroy() should wait for the in-flight index write, elapsedMs=${elapsedMs}ms delay=${INDEX_DELAY_MS}ms`,
       );
 
-      // The underlying client.destroy was called *after* the index landed.
-      // The default `assert(...)` import carries an `asserts value` type
-      // predicate (whereas the namespaced `assert.notEqual` does not), so
-      // it doubles as a type narrower for the timestamp variable.
       assert(clientDestroyCalledAt !== null, 'client.destroy should have been invoked');
       assert.ok(
         indexKeyVisibleAtDestroy,
         'the index entry should have been observable to client.destroy, meaning the drain ran first',
       );
 
-      // After destroy returns, the index is fully on disk.
       assert.equal(client.keysWithPrefix('agent/index/threads-by-date/').length, 1);
-      // And the timer wasn't somehow optimised away — destroy was reached
-      // after the createThread call (sanity check on the captured timestamps).
       assert.ok(clientDestroyCalledAt >= createReturnedAt);
     });
 
     it('destroy() drains a write that arrives during a previous drain iteration', async () => {
-      // This is the precise scenario the `while`-loop drain in
-      // `awaitPendingWrites` guards against: a `createThread` call
-      // lands while `destroy()` is already in the middle of an
-      // `await Promise.allSettled([...this.pendingIndexWrites])` for
-      // the first batch of in-flight writes. The first
-      // `Promise.allSettled`'s snapshot was taken at the moment
-      // `destroy()` started — the late-arriving createThread's
-      // background-PUT promise is added to the Set *after* that
-      // snapshot, so a one-shot drain (without the surrounding
-      // `while`-loop) would miss it and let `destroy()` return
-      // before the second PUT had settled. The loop notices the Set
-      // is still non-empty after the first iteration's `allSettled`
-      // resolves (the late entry's the only one left), takes a
-      // fresh snapshot, and waits on the late arrival too.
-      //
-      // The test engineers the timing window by holding the
-      // destroy-promise without awaiting it, then firing a second
-      // `createThread`. The microtask discipline guarantees the
-      // second createThread's body runs and adds its background-PUT
-      // promise to the Set before the first iteration's
-      // `Promise.allSettled` resolves, since the first PUT's
-      // artificial delay is large compared to the time it takes for
-      // the second createThread's synchronous-up-to-the-first-await
-      // body to enqueue its own background PUT.
       const client = new MapStorageClient();
       const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
 
@@ -702,30 +580,10 @@ describe('test/OSSAgentStore.test.ts', () => {
         'thread1\'s index PUT should still be in flight at this instant',
       );
 
-      // Hold the destroy-promise without awaiting yet, so the test
-      // code can interleave a second createThread between the
-      // start of the drain and its first `Promise.allSettled`
-      // settling.
       const destroyP = localStore.destroy();
-
-      // The second createThread runs its synchronous prelude (meta
-      // PUT, which the in-memory MapStorageClient resolves on the
-      // next microtask), then synchronously kicks off the second
-      // background index PUT and adds it to the in-flight Set.
-      // Because the in-memory meta PUT is microtask-fast and the
-      // first thread's index PUT is on an 80 ms setTimeout, the
-      // Set has both entries by the time the test awaits the
-      // second createThread's returned ThreadRecord.
       const thread2 = await localStore.createThread({ ordinal: 2 });
-
-      // Now wait for destroy() to finish. The destroy's
-      // awaitPendingWrites loop sees the Set is still non-empty
-      // after the first `Promise.allSettled` resolves (thread2's
-      // PUT is on its own timer that's a few ms behind thread1's),
-      // takes a fresh snapshot, and waits on the second PUT.
       await destroyP;
 
-      // Both index entries are present in the in-memory map.
       const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/');
       assert.equal(
         indexKeys.length,
@@ -752,14 +610,11 @@ describe('test/OSSAgentStore.test.ts', () => {
         `awaitPendingWrites with an empty queue should resolve immediately, took ${elapsedMs}ms`,
       );
 
-      // Should also be safe to call repeatedly with no in-flight writes
-      // between calls.
       await localStore.awaitPendingWrites();
       await localStore.awaitPendingWrites();
     });
 
     it('uses the normalized prefix on the index path, including the empty-prefix case', async () => {
-      // Empty prefix → index path has no leading separator.
       const bareClient = new MapStorageClient();
       const bareStore = new OSSAgentStore({ client: bareClient });
       await withFixedNow(T_MID, () => bareStore.createThread());
@@ -769,8 +624,6 @@ describe('test/OSSAgentStore.test.ts', () => {
       assert.ok(!bareIndex[0].startsWith('/'), `expected no leading "/", got ${bareIndex[0]}`);
       assert.match(bareIndex[0], INDEX_KEY_RE_ANY);
 
-      // Multi-segment prefix without trailing slash → same as the meta-key
-      // normalization rule already exercised by the existing 'prefix' suite.
       const nestedClient = new MapStorageClient();
       const nestedStore = new OSSAgentStore({ client: nestedClient, prefix: 'a/b' });
       await withFixedNow(T_MID, () => nestedStore.createThread());
@@ -779,7 +632,6 @@ describe('test/OSSAgentStore.test.ts', () => {
       assert.equal(nestedIndex.length, 1, `expected exactly one nested index entry: ${JSON.stringify(nestedClient.keys())}`);
       assert.match(nestedIndex[0], /^a\/b\/index\/threads-by-date\/2025-11-13\/\d{13}_thread_[0-9a-f-]+$/);
 
-      // The threadId tail in the key matches the meta.json's id.
       const metaKey = nestedClient.keys().find(k => k.startsWith('a/b/threads/') && k.endsWith('/meta.json'));
       assert.ok(metaKey, 'meta.json key for the nested prefix should exist');
       const expectedThreadId = metaKey.slice('a/b/threads/'.length, -('/meta.json'.length));

--- a/core/agent-runtime/test/OSSAgentStore.test.ts
+++ b/core/agent-runtime/test/OSSAgentStore.test.ts
@@ -2,7 +2,13 @@ import assert from 'node:assert';
 
 import type { AgentMessage } from '@eggjs/tegg-types/agent-runtime';
 
-import { AgentNotFoundError, OSSAgentStore } from '../index';
+import {
+  AgentNotFoundError,
+  OSSAgentStore,
+  TS_MAX_MS,
+  decodeReverseMs,
+  reverseMs,
+} from '../index';
 import { MapStorageClient, MapStorageClientWithoutAppend } from './helpers';
 
 describe('test/OSSAgentStore.test.ts', () => {
@@ -291,6 +297,437 @@ describe('test/OSSAgentStore.test.ts', () => {
           return true;
         },
       );
+    });
+  });
+
+  describe('thread time index', () => {
+    // Drive Date.now() to a fixed millisecond value for the duration of `fn`,
+    // then restore the real clock — used so we can predict the index key bytes.
+    function withFixedNow<T>(ms: number, fn: () => Promise<T>): Promise<T> {
+      const realNow = Date.now;
+      Date.now = () => ms;
+      return Promise.resolve()
+        .then(fn)
+        .finally(() => {
+          Date.now = realNow;
+        });
+    }
+
+    // The shape every fully-prefixed (`agent/`) time-index key should match:
+    // `agent/index/threads-by-date/<YYYY-MM-DD>/<13-digit-revMs>_<thread_<uuid>>`.
+    const INDEX_KEY_RE_AGENT = /^agent\/index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_[0-9a-f-]+$/;
+    // Same shape but allowing any prefix segment (including the empty prefix).
+    const INDEX_KEY_RE_ANY = /^(?:[^/]+(?:\/[^/]+)*\/)?index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_[0-9a-f-]+$/;
+
+    // Three sample wall-clock instants we use repeatedly. All Date.UTC arguments
+    // are zero-indexed in the month slot (so 10 means November).
+    const T_EARLY = Date.UTC(2025, 10, 13, 8, 0, 0, 0); //  2025-11-13T08:00:00.000Z = 1763020800000 ms
+    const T_MID = Date.UTC(2025, 10, 13, 8, 0, 1, 234); //  2025-11-13T08:00:01.234Z = 1763020801234 ms
+    const T_LATE = Date.UTC(2025, 10, 13, 10, 0, 0, 0); //  2025-11-13T10:00:00.000Z = 1763028000000 ms
+
+    it('writes a sidecar time index next to meta.json on createThread', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const thread = await withFixedNow(T_MID, () => localStore.createThread({ user: 'alice' }));
+      await localStore.awaitPendingWrites();
+
+      const keys = client.keys();
+      assert.ok(
+        keys.includes(`agent/threads/${thread.id}/meta.json`),
+        `meta.json not found amongst keys: ${JSON.stringify(keys)}`,
+      );
+
+      const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/');
+      assert.equal(indexKeys.length, 1, `expected exactly one index entry, got ${JSON.stringify(indexKeys)}`);
+      const indexKey = indexKeys[0];
+      assert.match(indexKey, INDEX_KEY_RE_AGENT);
+
+      const expectedRev = reverseMs(T_MID);
+      const expectedKey = `agent/index/threads-by-date/2025-11-13/${expectedRev}_${thread.id}`;
+      assert.equal(indexKey, expectedKey);
+
+      // The suffix is a faithful encoding: decoding it recovers the original ms.
+      const fileName = indexKey.slice(indexKey.lastIndexOf('/') + 1);
+      const decoded = decodeReverseMs(fileName.slice(0, fileName.indexOf('_')));
+      assert.equal(decoded, T_MID);
+      // TS_MAX_MS export is the operand the encoder used.
+      assert.equal(parseInt(fileName.slice(0, fileName.indexOf('_')), 10), TS_MAX_MS - T_MID);
+    });
+
+    it('the index body carries threadId, Unix-second createdAt and a snapshot of metadata', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+      const meta: Record<string, unknown> = { user: 'alice', channel: 'web' };
+
+      const thread = await withFixedNow(T_MID, () => localStore.createThread(meta));
+      await localStore.awaitPendingWrites();
+
+      const indexKey = client.keysWithPrefix('agent/index/threads-by-date/')[0];
+      const raw = await client.get(indexKey);
+      assert.ok(raw, 'index body should be present after drain');
+      const body = JSON.parse(raw) as { threadId: string; createdAt: number; metadata: Record<string, unknown> };
+
+      assert.deepStrictEqual(body, {
+        threadId: thread.id,
+        createdAt: Math.floor(T_MID / 1000),
+        metadata: { user: 'alice', channel: 'web' },
+      });
+      // The body's createdAt is the same Unix-second value as the thread record's,
+      // because both derive from a single Date.now() reading.
+      assert.strictEqual(body.createdAt, thread.createdAt);
+
+      // The body is a JSON snapshot taken at write time — mutating the original
+      // metadata object after the fact must not be reflected in the persisted
+      // body, since the OSSAgentStore wrote a serialized copy.
+      meta.user = 'mutated';
+      const reread = JSON.parse((await client.get(indexKey))!) as typeof body;
+      assert.equal(reread.metadata.user, 'alice');
+    });
+
+    it('within a date directory, ASC dictionary order equals time-DESC creation order', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const early = await withFixedNow(T_EARLY, () => localStore.createThread({ tag: 'early' }));
+      const mid = await withFixedNow(T_MID, () => localStore.createThread({ tag: 'mid' }));
+      const late = await withFixedNow(T_LATE, () => localStore.createThread({ tag: 'late' }));
+      await localStore.awaitPendingWrites();
+
+      // keysWithPrefix returns the array already sorted ASCII-ascending, which
+      // is also how an OSS ListObjects would return the keys.
+      const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/2025-11-13/');
+      assert.equal(indexKeys.length, 3);
+
+      const threadIdsInListOrder = indexKeys.map(k => {
+        const fileName = k.slice(k.lastIndexOf('/') + 1);
+        return fileName.slice(fileName.indexOf('_') + 1);
+      });
+      // Newest first because the suffix is the time complement.
+      assert.deepStrictEqual(threadIdsInListOrder, [ late.id, mid.id, early.id ]);
+
+      const revs = indexKeys.map(k => {
+        const fileName = k.slice(k.lastIndexOf('/') + 1);
+        return fileName.slice(0, fileName.indexOf('_'));
+      });
+      assert.deepStrictEqual(revs, [ reverseMs(T_LATE), reverseMs(T_MID), reverseMs(T_EARLY) ]);
+      assert.ok(revs[0] < revs[1] && revs[1] < revs[2], 'revs must be ASCII-ascending');
+    });
+
+    it('threads created on either side of a UTC day boundary land in different date buckets', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const lastMsOfNov13Utc = Date.UTC(2025, 10, 13, 23, 59, 59, 999);
+      const firstMsOfNov14Utc = Date.UTC(2025, 10, 14, 0, 0, 0, 0);
+
+      const earlier = await withFixedNow(lastMsOfNov13Utc, () => localStore.createThread());
+      const later = await withFixedNow(firstMsOfNov14Utc, () => localStore.createThread());
+      await localStore.awaitPendingWrites();
+
+      const nov13 = client.keysWithPrefix('agent/index/threads-by-date/2025-11-13/');
+      const nov14 = client.keysWithPrefix('agent/index/threads-by-date/2025-11-14/');
+      assert.equal(nov13.length, 1, `Nov 13 bucket: ${JSON.stringify(nov13)}`);
+      assert.equal(nov14.length, 1, `Nov 14 bucket: ${JSON.stringify(nov14)}`);
+      assert.ok(nov13[0].endsWith(`_${earlier.id}`));
+      assert.ok(nov14[0].endsWith(`_${later.id}`));
+    });
+
+    it('honors the dateTimezone option when picking the day bucket', async () => {
+      // UTC 18:00 maps to next-day 02:00 in Asia/Shanghai (UTC+8, no DST).
+      const physicalMs = Date.UTC(2025, 10, 13, 18, 0, 0, 0);
+
+      const shanghaiClient = new MapStorageClient();
+      const shanghaiStore = new OSSAgentStore({
+        client: shanghaiClient,
+        prefix: 'agent/',
+        dateTimezone: 'Asia/Shanghai',
+      });
+      await withFixedNow(physicalMs, () => shanghaiStore.createThread());
+      await shanghaiStore.awaitPendingWrites();
+
+      assert.equal(
+        shanghaiClient.keysWithPrefix('agent/index/threads-by-date/2025-11-14/').length,
+        1,
+        'Shanghai store should bucket UTC 18:00 into the +08 next-day directory',
+      );
+      assert.equal(
+        shanghaiClient.keysWithPrefix('agent/index/threads-by-date/2025-11-13/').length,
+        0,
+      );
+
+      const utcClient = new MapStorageClient();
+      const utcStore = new OSSAgentStore({ client: utcClient, prefix: 'agent/' });
+      await withFixedNow(physicalMs, () => utcStore.createThread());
+      await utcStore.awaitPendingWrites();
+
+      assert.equal(
+        utcClient.keysWithPrefix('agent/index/threads-by-date/2025-11-13/').length,
+        1,
+        'Default-UTC store should bucket the same instant into the same-day UTC directory',
+      );
+      assert.equal(
+        utcClient.keysWithPrefix('agent/index/threads-by-date/2025-11-14/').length,
+        0,
+      );
+    });
+
+    it('createThread does not wait for the index PUT to complete (non-blocking)', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const INDEX_DELAY_MS = 120;
+      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-date\//, INDEX_DELAY_MS);
+
+      const t0 = Date.now();
+      const thread = await localStore.createThread();
+      const elapsedMs = Date.now() - t0;
+
+      // The meta.json PUT against an in-memory Map resolves on the next
+      // microtask, so any latency over ~10 ms here would indicate that the
+      // 120 ms artificial delay on the *index* key wormed its way onto the
+      // caller's await chain. A generous bound of (DELAY - 50) ms keeps the
+      // assertion robust against scheduling jitter on shared CI without
+      // making the assertion vacuous.
+      assert.ok(
+        elapsedMs < INDEX_DELAY_MS - 50,
+        `createThread should return before the index PUT settles, but elapsed=${elapsedMs}ms (delay=${INDEX_DELAY_MS}ms)`,
+      );
+
+      // At this exact instant the index key is not yet visible.
+      assert.equal(
+        client.keysWithPrefix('agent/index/').length,
+        0,
+        'the slow background PUT should not be visible at the moment createThread returns',
+      );
+
+      // The meta.json is, however, already on disk.
+      assert.ok(await client.get(`agent/threads/${thread.id}/meta.json`));
+
+      // After we explicitly drain the queue, the index does land.
+      await localStore.awaitPendingWrites();
+      const indexKeys = client.keysWithPrefix('agent/index/threads-by-date/');
+      assert.equal(indexKeys.length, 1);
+      assert.ok(indexKeys[0].endsWith(`_${thread.id}`));
+    });
+
+    it('createThread succeeds even when the index PUT throws; the failure becomes a single warn line', async () => {
+      const client = new MapStorageClient();
+      client.failPutWhenKeyMatches(/^agent\/index\/threads-by-date\//);
+
+      const warnCalls: unknown[][] = [];
+      const logger = {
+        warn(message: string, ...args: unknown[]): void {
+          warnCalls.push([ message, ...args ]);
+        },
+      };
+      const localStore = new OSSAgentStore({
+        client,
+        prefix: 'agent/',
+        logger,
+      });
+
+      // createThread itself resolves cleanly. The injected put failure for
+      // the index key is observed only as a warn line.
+      const thread = await localStore.createThread({ trace: 'fail-path' });
+      assert.equal(thread.object, 'thread');
+      assert.match(thread.id, /^thread_[0-9a-f-]{36}$/);
+
+      // awaitPendingWrites should also not throw — `Promise.allSettled` swallows
+      // the rejection that the catch handler converted into a warn.
+      await localStore.awaitPendingWrites();
+
+      // Main data is intact.
+      const metaRaw = await client.get(`agent/threads/${thread.id}/meta.json`);
+      assert.ok(metaRaw, 'meta.json should still be present when only the index PUT failed');
+      const metaObj = JSON.parse(metaRaw) as { id: string; createdAt: number };
+      assert.equal(metaObj.id, thread.id);
+      assert.equal(metaObj.createdAt, thread.createdAt);
+
+      // No index objects were written.
+      assert.equal(
+        client.keysWithPrefix('agent/index/').length,
+        0,
+        'the simulated index PUT failure means no index entries exist',
+      );
+
+      // Exactly one warn invocation, carrying threadId / indexKey / errMessage as the trailing args.
+      assert.equal(warnCalls.length, 1, `expected one warn call, got ${warnCalls.length}: ${JSON.stringify(warnCalls)}`);
+      const call = warnCalls[0];
+      const formatStr = call[0];
+      assert.equal(typeof formatStr, 'string');
+      assert.ok(
+        (formatStr as string).includes('failed to write thread time index'),
+        `unexpected warn format string: ${String(formatStr)}`,
+      );
+      assert.equal(call[1], thread.id);
+      assert.match(call[2] as string, /^agent\/index\/threads-by-date\/\d{4}-\d{2}-\d{2}\/\d{13}_thread_/);
+      assert.match(call[3] as string, /simulated PUT failure/);
+
+      // And the read path keeps working — getThread does not consult the index.
+      const fetched = await localStore.getThread(thread.id);
+      assert.equal(fetched.id, thread.id);
+    });
+
+    it('with no logger configured, an index PUT failure falls back to console.warn without throwing', async () => {
+      const client = new MapStorageClient();
+      client.failPutWhenKeyMatches(/^agent\/index\/threads-by-date\//);
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      // Intercept console.warn so the suite stays quiet and we can confirm the fallback wired up.
+      const realWarn = console.warn;
+      const captured: unknown[][] = [];
+      console.warn = ((...args: unknown[]) => {
+        captured.push(args);
+      }) as typeof console.warn;
+
+      try {
+        const thread = await localStore.createThread();
+        await localStore.awaitPendingWrites();
+        assert.equal(captured.length, 1);
+        const args = captured[0];
+        assert.equal(typeof args[0], 'string');
+        assert.ok((args[0] as string).includes('failed to write thread time index'));
+        assert.equal(args[1], thread.id);
+      } finally {
+        console.warn = realWarn;
+      }
+    });
+
+    it('destroy() drains in-flight index writes before tearing down the underlying client', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const INDEX_DELAY_MS = 120;
+      client.delayPutWhenKeyMatches(/^agent\/index\/threads-by-date\//, INDEX_DELAY_MS);
+
+      // Capture the moment the underlying client's destroy gets called, so we
+      // can sequence "drain finishes, then client.destroy fires". The base
+      // MapStorageClient has no destroy method, so we attach one for this test.
+      let clientDestroyCalledAt: number | null = null;
+      let indexKeyVisibleAtDestroy = false;
+      client.destroy = async () => {
+        clientDestroyCalledAt = Date.now();
+        indexKeyVisibleAtDestroy = client.keysWithPrefix('agent/index/').length > 0;
+      };
+
+      const createReturnedAt = Date.now();
+      await localStore.createThread();
+      // The slow PUT is still in flight.
+      assert.equal(client.keysWithPrefix('agent/index/').length, 0);
+
+      const beforeDestroy = Date.now();
+      await localStore.destroy();
+      const elapsedMs = Date.now() - beforeDestroy;
+
+      // destroy waited for the 120 ms PUT to settle. Allow a small (10 ms)
+      // tolerance window in case of sub-millisecond timer skew.
+      assert.ok(
+        elapsedMs >= INDEX_DELAY_MS - 20,
+        `destroy() should wait for the in-flight index write, elapsedMs=${elapsedMs}ms delay=${INDEX_DELAY_MS}ms`,
+      );
+
+      // The underlying client.destroy was called *after* the index landed.
+      // The default `assert(...)` import carries an `asserts value` type
+      // predicate (whereas the namespaced `assert.notEqual` does not), so
+      // it doubles as a type narrower for the timestamp variable.
+      assert(clientDestroyCalledAt !== null, 'client.destroy should have been invoked');
+      assert.ok(
+        indexKeyVisibleAtDestroy,
+        'the index entry should have been observable to client.destroy, meaning the drain ran first',
+      );
+
+      // After destroy returns, the index is fully on disk.
+      assert.equal(client.keysWithPrefix('agent/index/threads-by-date/').length, 1);
+      // And the timer wasn't somehow optimised away — destroy was reached
+      // after the createThread call (sanity check on the captured timestamps).
+      assert.ok(clientDestroyCalledAt >= createReturnedAt);
+    });
+
+    it('awaitPendingWrites() is a no-op resolved promise when there are no pending writes', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const t0 = Date.now();
+      await localStore.awaitPendingWrites();
+      const elapsedMs = Date.now() - t0;
+      assert.ok(
+        elapsedMs < 50,
+        `awaitPendingWrites with an empty queue should resolve immediately, took ${elapsedMs}ms`,
+      );
+
+      // Should also be safe to call repeatedly with no in-flight writes
+      // between calls.
+      await localStore.awaitPendingWrites();
+      await localStore.awaitPendingWrites();
+    });
+
+    it('uses the normalized prefix on the index path, including the empty-prefix case', async () => {
+      // Empty prefix → index path has no leading separator.
+      const bareClient = new MapStorageClient();
+      const bareStore = new OSSAgentStore({ client: bareClient });
+      await withFixedNow(T_MID, () => bareStore.createThread());
+      await bareStore.awaitPendingWrites();
+      const bareIndex = bareClient.keysWithPrefix('index/threads-by-date/');
+      assert.equal(bareIndex.length, 1);
+      assert.ok(!bareIndex[0].startsWith('/'), `expected no leading "/", got ${bareIndex[0]}`);
+      assert.match(bareIndex[0], INDEX_KEY_RE_ANY);
+
+      // Multi-segment prefix without trailing slash → same as the meta-key
+      // normalization rule already exercised by the existing 'prefix' suite.
+      const nestedClient = new MapStorageClient();
+      const nestedStore = new OSSAgentStore({ client: nestedClient, prefix: 'a/b' });
+      await withFixedNow(T_MID, () => nestedStore.createThread());
+      await nestedStore.awaitPendingWrites();
+      const nestedIndex = nestedClient.keysWithPrefix('a/b/index/threads-by-date/');
+      assert.equal(nestedIndex.length, 1, `expected exactly one nested index entry: ${JSON.stringify(nestedClient.keys())}`);
+      assert.match(nestedIndex[0], /^a\/b\/index\/threads-by-date\/2025-11-13\/\d{13}_thread_[0-9a-f-]+$/);
+
+      // The threadId tail in the key matches the meta.json's id.
+      const metaKey = nestedClient.keys().find(k => k.startsWith('a/b/threads/') && k.endsWith('/meta.json'));
+      assert.ok(metaKey, 'meta.json key for the nested prefix should exist');
+      const expectedThreadId = metaKey.slice('a/b/threads/'.length, -('/meta.json'.length));
+      assert.ok(nestedIndex[0].endsWith(`_${expectedThreadId}`));
+    });
+
+    it('appendMessages, createRun, and updateRun never touch the time index after createThread', async () => {
+      const client = new MapStorageClient();
+      const localStore = new OSSAgentStore({ client, prefix: 'agent/' });
+
+      const thread = await localStore.createThread({ origin: 'audit' });
+      await localStore.awaitPendingWrites();
+      const indexKeysBefore = client.keysWithPrefix('agent/index/').slice();
+      const indexBodyBefore = await client.get(indexKeysBefore[0]);
+      assert.equal(indexKeysBefore.length, 1, 'baseline: exactly one index entry from createThread');
+
+      const messages: AgentMessage[] = [
+        { type: 'user', message: { role: 'user', content: 'hello' } } as unknown as AgentMessage,
+        {
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+        } as unknown as AgentMessage,
+      ];
+      await localStore.appendMessages(thread.id, messages);
+
+      const run = await localStore.createRun(
+        [{ role: 'user', content: 'first turn' }],
+        thread.id,
+        { maxIterations: 1 },
+        { trace: 't' },
+      );
+      await localStore.updateRun(run.id, {
+        status: 'completed',
+        completedAt: Math.floor(Date.now() / 1000),
+      });
+
+      const indexKeysAfter = client.keysWithPrefix('agent/index/').slice();
+      assert.deepStrictEqual(
+        indexKeysAfter.slice().sort(),
+        indexKeysBefore.slice().sort(),
+        'no new index keys should appear; the index entry is the immutable thread-birth record',
+      );
+      const indexBodyAfter = await client.get(indexKeysAfter[0]);
+      assert.equal(indexBodyAfter, indexBodyBefore, 'the index body should be byte-identical');
     });
   });
 });

--- a/core/agent-runtime/test/OSSAgentStore.test.ts
+++ b/core/agent-runtime/test/OSSAgentStore.test.ts
@@ -5,8 +5,6 @@ import type { AgentMessage } from '@eggjs/tegg-types/agent-runtime';
 import {
   AgentNotFoundError,
   OSSAgentStore,
-  TS_MAX_MS,
-  decodeReverseMs,
   reverseMs,
 } from '../index';
 import { MapStorageClient, MapStorageClientWithoutAppend } from './helpers';
@@ -339,11 +337,6 @@ describe('test/OSSAgentStore.test.ts', () => {
       const expectedRev = reverseMs(T_MID);
       const expectedKey = `agent/index/threads-by-date/2025-11-13/${expectedRev}_${thread.id}`;
       assert.equal(indexKey, expectedKey);
-
-      const fileName = indexKey.slice(indexKey.lastIndexOf('/') + 1);
-      const decoded = decodeReverseMs(fileName.slice(0, fileName.indexOf('_')));
-      assert.equal(decoded, T_MID);
-      assert.equal(parseInt(fileName.slice(0, fileName.indexOf('_')), 10), TS_MAX_MS - T_MID);
     });
 
     it('the index body carries threadId, Unix-second createdAt and a snapshot of metadata', async () => {

--- a/core/agent-runtime/test/helpers.ts
+++ b/core/agent-runtime/test/helpers.ts
@@ -1,12 +1,87 @@
 import type { ObjectStorageClient } from '@eggjs/tegg-types/agent-runtime';
 
+interface PutDelayRule {
+  pattern: RegExp;
+  ms: number;
+}
+
+/**
+ * Inspect every key matched against the failure-injection state and throw a
+ * deterministic error if a hit is found. Shared between the two test clients.
+ */
+function shouldFailPut(
+  key: string,
+  exact: ReadonlySet<string>,
+  pattern: RegExp | null,
+): boolean {
+  return exact.has(key) || (pattern !== null && pattern.test(key));
+}
+
+/** Resolve a delay rule for `key`, or `undefined` if no rule matches. */
+function findPutDelay(key: string, rules: readonly PutDelayRule[]): PutDelayRule | undefined {
+  return rules.find(r => r.pattern.test(key));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
 /** In-memory ObjectStorageClient backed by a Map — for testing only. */
 export class MapStorageClient implements ObjectStorageClient {
   private readonly store = new Map<string, string>();
+  private readonly putFailureExact = new Set<string>();
+  private putFailurePattern: RegExp | null = null;
+  private readonly putDelays: PutDelayRule[] = [];
+
   init?(): Promise<void>;
   destroy?(): Promise<void>;
 
+  /** Test helper: snapshot of every stored key, sorted ASCII-ascending. */
+  keys(): string[] {
+    return [ ...this.store.keys() ].sort();
+  }
+
+  /** Test helper: snapshot of stored keys whose prefix matches `prefix`. */
+  keysWithPrefix(prefix: string): string[] {
+    return this.keys().filter(k => k.startsWith(prefix));
+  }
+
+  /** Test helper: make subsequent `put`s whose key matches `pattern` reject. */
+  failPutWhenKeyMatches(pattern: RegExp): void {
+    this.putFailurePattern = pattern;
+  }
+
+  /** Test helper: make a single `put(key)` reject. */
+  failPutForExactKey(key: string): void {
+    this.putFailureExact.add(key);
+  }
+
+  /** Test helper: remove all PUT-failure injection rules. */
+  clearPutFailures(): void {
+    this.putFailureExact.clear();
+    this.putFailurePattern = null;
+  }
+
+  /** Test helper: delay `put`s matching `pattern` by `ms` milliseconds. */
+  delayPutWhenKeyMatches(pattern: RegExp, ms: number): void {
+    this.putDelays.push({ pattern, ms });
+  }
+
+  /** Test helper: remove all PUT-delay injection rules. */
+  clearPutDelays(): void {
+    this.putDelays.length = 0;
+  }
+
   async put(key: string, value: string): Promise<void> {
+    if (shouldFailPut(key, this.putFailureExact, this.putFailurePattern)) {
+      throw new Error(`MapStorageClient: simulated PUT failure for ${key}`);
+    }
+    const delay = findPutDelay(key, this.putDelays);
+    if (delay) {
+      await sleep(delay.ms);
+    }
     this.store.set(key, value);
   }
 
@@ -15,18 +90,64 @@ export class MapStorageClient implements ObjectStorageClient {
   }
 
   async append(key: string, value: string): Promise<void> {
+    // append is not subject to the time-index failure-injection hooks,
+    // since the time index is written via `put`, not `append`.
     const existing = this.store.get(key) ?? '';
     this.store.set(key, existing + value);
   }
 }
 
-/** MapStorageClient variant without append — tests the get-concat-put fallback path. */
+/**
+ * MapStorageClient variant without `append` — exercises OSSAgentStore's
+ * get-concat-put fallback path for message appends. The test-control hooks
+ * (`keys`, `failPut*`, `delayPut*`) mirror `MapStorageClient`'s.
+ */
 export class MapStorageClientWithoutAppend implements ObjectStorageClient {
   private readonly store = new Map<string, string>();
+  private readonly putFailureExact = new Set<string>();
+  private putFailurePattern: RegExp | null = null;
+  private readonly putDelays: PutDelayRule[] = [];
+
   init?(): Promise<void>;
   destroy?(): Promise<void>;
 
+  keys(): string[] {
+    return [ ...this.store.keys() ].sort();
+  }
+
+  keysWithPrefix(prefix: string): string[] {
+    return this.keys().filter(k => k.startsWith(prefix));
+  }
+
+  failPutWhenKeyMatches(pattern: RegExp): void {
+    this.putFailurePattern = pattern;
+  }
+
+  failPutForExactKey(key: string): void {
+    this.putFailureExact.add(key);
+  }
+
+  clearPutFailures(): void {
+    this.putFailureExact.clear();
+    this.putFailurePattern = null;
+  }
+
+  delayPutWhenKeyMatches(pattern: RegExp, ms: number): void {
+    this.putDelays.push({ pattern, ms });
+  }
+
+  clearPutDelays(): void {
+    this.putDelays.length = 0;
+  }
+
   async put(key: string, value: string): Promise<void> {
+    if (shouldFailPut(key, this.putFailureExact, this.putFailurePattern)) {
+      throw new Error(`MapStorageClientWithoutAppend: simulated PUT failure for ${key}`);
+    }
+    const delay = findPutDelay(key, this.putDelays);
+    if (delay) {
+      await sleep(delay.ms);
+    }
     this.store.set(key, value);
   }
 

--- a/core/agent-runtime/test/helpers.ts
+++ b/core/agent-runtime/test/helpers.ts
@@ -45,21 +45,8 @@ export class MapStorageClient implements ObjectStorageClient {
     this.putFailurePattern = pattern;
   }
 
-  failPutForExactKey(key: string): void {
-    this.putFailureExact.add(key);
-  }
-
-  clearPutFailures(): void {
-    this.putFailureExact.clear();
-    this.putFailurePattern = null;
-  }
-
   delayPutWhenKeyMatches(pattern: RegExp, ms: number): void {
     this.putDelays.push({ pattern, ms });
-  }
-
-  clearPutDelays(): void {
-    this.putDelays.length = 0;
   }
 
   async put(key: string, value: string): Promise<void> {
@@ -105,21 +92,8 @@ export class MapStorageClientWithoutAppend implements ObjectStorageClient {
     this.putFailurePattern = pattern;
   }
 
-  failPutForExactKey(key: string): void {
-    this.putFailureExact.add(key);
-  }
-
-  clearPutFailures(): void {
-    this.putFailureExact.clear();
-    this.putFailurePattern = null;
-  }
-
   delayPutWhenKeyMatches(pattern: RegExp, ms: number): void {
     this.putDelays.push({ pattern, ms });
-  }
-
-  clearPutDelays(): void {
-    this.putDelays.length = 0;
   }
 
   async put(key: string, value: string): Promise<void> {

--- a/core/agent-runtime/test/helpers.ts
+++ b/core/agent-runtime/test/helpers.ts
@@ -5,10 +5,6 @@ interface PutDelayRule {
   ms: number;
 }
 
-/**
- * Inspect every key matched against the failure-injection state and throw a
- * deterministic error if a hit is found. Shared between the two test clients.
- */
 function shouldFailPut(
   key: string,
   exact: ReadonlySet<string>,
@@ -17,7 +13,6 @@ function shouldFailPut(
   return exact.has(key) || (pattern !== null && pattern.test(key));
 }
 
-/** Resolve a delay rule for `key`, or `undefined` if no rule matches. */
 function findPutDelay(key: string, rules: readonly PutDelayRule[]): PutDelayRule | undefined {
   return rules.find(r => r.pattern.test(key));
 }
@@ -38,38 +33,31 @@ export class MapStorageClient implements ObjectStorageClient {
   init?(): Promise<void>;
   destroy?(): Promise<void>;
 
-  /** Test helper: snapshot of every stored key, sorted ASCII-ascending. */
   keys(): string[] {
     return [ ...this.store.keys() ].sort();
   }
 
-  /** Test helper: snapshot of stored keys whose prefix matches `prefix`. */
   keysWithPrefix(prefix: string): string[] {
     return this.keys().filter(k => k.startsWith(prefix));
   }
 
-  /** Test helper: make subsequent `put`s whose key matches `pattern` reject. */
   failPutWhenKeyMatches(pattern: RegExp): void {
     this.putFailurePattern = pattern;
   }
 
-  /** Test helper: make a single `put(key)` reject. */
   failPutForExactKey(key: string): void {
     this.putFailureExact.add(key);
   }
 
-  /** Test helper: remove all PUT-failure injection rules. */
   clearPutFailures(): void {
     this.putFailureExact.clear();
     this.putFailurePattern = null;
   }
 
-  /** Test helper: delay `put`s matching `pattern` by `ms` milliseconds. */
   delayPutWhenKeyMatches(pattern: RegExp, ms: number): void {
     this.putDelays.push({ pattern, ms });
   }
 
-  /** Test helper: remove all PUT-delay injection rules. */
   clearPutDelays(): void {
     this.putDelays.length = 0;
   }
@@ -90,18 +78,12 @@ export class MapStorageClient implements ObjectStorageClient {
   }
 
   async append(key: string, value: string): Promise<void> {
-    // append is not subject to the time-index failure-injection hooks,
-    // since the time index is written via `put`, not `append`.
     const existing = this.store.get(key) ?? '';
     this.store.set(key, existing + value);
   }
 }
 
-/**
- * MapStorageClient variant without `append` — exercises OSSAgentStore's
- * get-concat-put fallback path for message appends. The test-control hooks
- * (`keys`, `failPut*`, `delayPut*`) mirror `MapStorageClient`'s.
- */
+/** MapStorageClient variant without `append`. */
 export class MapStorageClientWithoutAppend implements ObjectStorageClient {
   private readonly store = new Map<string, string>();
   private readonly putFailureExact = new Set<string>();


### PR DESCRIPTION
## Summary

- Adds a sidecar object at `{prefix}index/threads-by-date/YYYY-MM-DD/{revMs13}_{threadId}` on every successful `OSSAgentStore.createThread`, so analytics tooling that points directly at the bucket can enumerate threads by creation day without first GET'ing each `meta.json`.
- The suffix is the decimal complement of the millisecond timestamp (`9_999_999_999_999 - Date.now()`, zero-padded to 13 chars), so the natural ASCII-ascending order an OSS / S3 `ListObjects` call returns is the same as creation-time *descending* within a date directory — a workaround for the lack of a reverse-order list in the S3 protocol family. The body is a compact `{"threadId":…, "createdAt":<Unix-seconds, same value as meta.json>, "metadata":{…}}` JSON, so a downstream consumer can avoid a second GET for the canonical metadata.
- The index PUT is fire-and-forget: it runs on a background promise tracked in an internal `Set` and contributes zero latency to `createThread`'s happy path. A rejection becomes one `warn` log line through a structurally-typed injected logger (falling back to `console.warn`) and never propagates. A new public `OSSAgentStore.awaitPendingWrites(): Promise<void>` drains the queue without ever rejecting; `destroy()` calls it before tearing down the underlying client so graceful shutdown doesn't drop in-flight writes.
- New `OSSAgentStoreOptions` fields, both optional with backwards-compatible defaults so existing call sites compile unchanged: `logger?: { warn(message, ...args): void }` (compatible with `EggLogger` and `console`; pass `app.logger` directly) and `dateTimezone?: string` (IANA name; defaults to `'UTC'` so workers in different physical regions agree on the day boundary, pass `'Asia/Shanghai'` etc. to follow a local-calendar analytics convention).
- New utility exports on the package root, intended for downstream backfill / analytics scripts that need to reproduce or decode the key shape: `TS_MAX_MS` (the 13-digit ceiling, ≈ year 2286), `reverseMs(ms)`, `decodeReverseMs(revMs13)`, and `dateBucket(ms, tz?)`. They live in `AgentStoreUtils` and ship via the existing `export *` re-export from `index.ts`.
- The `AgentStore` interface, the `ObjectStorageClient` interface, and `AgentRuntime` are intentionally **not** touched. The read path (`getThread`) does not consult the index, so the index can be eventually consistent — or entirely missing for historical threads — without affecting read semantics. Backfilling pre-existing threads is the consumer's responsibility; the exported helpers make it a one-liner over the existing `{prefix}threads/*/meta.json` keyspace.

### What an OSS prefix actually looks like

Given `prefix: 'agent/'` and four threads created at UTC `2025-11-13 08:00:00.000`, `08:00:01.234`, `10:00:00.000`, and `2025-11-14 00:00:00.000`, the bucket grows by the following four extra objects (alongside the existing `agent/threads/{id}/meta.json` files, which are unchanged):

```
oss://<bucket>/agent/index/threads-by-date/
├── 2025-11-13/
│   ├── 8236971999999_thread_…  ← 10:00:00.000Z, newest of the day, sorts first
│   ├── 8236979198765_thread_…  ← 08:00:01.234Z, middle
│   └── 8236979199999_thread_…  ← 08:00:00.000Z, oldest of the day, sorts last
└── 2025-11-14/
    └── 8236921599999_thread_…  ← cross-day rollover
```

`9_999_999_999_999 − 1_763_028_000_000 = 8_236_971_999_999` checks the algebra. A consumer that wants raw milliseconds back from a key calls `decodeReverseMs(suffix)`, which is `TS_MAX_MS − parseInt(suffix, 10)`. The body of each of the four entries is something like `{"threadId":"thread_018f…","createdAt":1763028000,"metadata":{}}`, with the `createdAt` Unix-second value byte-identical to `agent/threads/<that-id>/meta.json`'s `createdAt`, because both derive from a single `Date.now()` reading inside `createThread`.

## Test plan

- [x] `mocha` in `core/agent-runtime/` — the existing 100+ cases still pass, plus 24 new cases (12 in a new `test/AgentStoreUtils.test.ts` and 12 in a new `describe('thread time index')` block at the end of `test/OSSAgentStore.test.ts`). The only two failures in the workspace's full suite are `test/AgentRuntime.test.ts > cancelRun > "should fail the run and leave the thread empty when cancel waits past the commit timeout"` and `"should not overwrite watchdog-set Failed with Completed when executor finishes naturally without committing"`, both reporting `Uncaught TypeError: AgentTimeoutError is not a constructor` from a stray watchdog timer firing in `src/AgentRuntime.ts:565` — confirmed to reproduce identically on the stock `master@f4245c37` source without any of this PR's changes, so they are pre-existing flakes unrelated to this change.
- [x] `eslint core/agent-runtime --ext .ts` — clean. (Auto-fix touched two stylistic nits in the new test cases — alignment whitespace before `// 2025-11-13…` comments and `[ x ]` array-bracket-spacing — and they were re-reviewed by hand.)
- [x] `tsc -p tsconfig.pub.json` in `core/agent-runtime/` — the generated `dist/index.d.ts` exposes the new public surface: `TS_MAX_MS`, `reverseMs`, `decodeReverseMs`, `dateBucket`, `OSSAgentStore.awaitPendingWrites`, `OSSAgentStoreOptions.logger`, `OSSAgentStoreOptions.dateTimezone`, and the `OSSAgentStoreWarnLogger` interface.

The new test coverage explicitly exercises: the precise key shape (regex-matched), the body JSON contents and the snapshot-not-reference treatment of `metadata`, the within-day ASC == time-DESC invariant across three timestamps, the UTC-midnight day boundary, the `dateTimezone: 'Asia/Shanghai'` override flipping the bucket name versus the same physical instant under default UTC, the non-blocking-latency property (the test client artificially delays index-key PUTs by 120 ms and asserts `createThread` returns in well under that), the warn-logged failure path with both an explicit injected logger and the `console.warn` fallback, the `destroy()` drain semantics with the same 120 ms artificial delay, prefix normalisation in both the empty-prefix and non-trailing-slash cases, the no-op behaviour of `awaitPendingWrites()` on an empty queue, and the immutability invariant that `appendMessages` / `createRun` / `updateRun` never touch any `index/…` key after the initial creation. The `MapStorageClient` and `MapStorageClientWithoutAppend` test helpers gained `keys()`, `keysWithPrefix(prefix)`, `failPutWhenKeyMatches(re)`, `failPutForExactKey(k)`, `clearPutFailures()`, `delayPutWhenKeyMatches(re, ms)`, and `clearPutDelays()` hooks for these scenarios — all confined to the test helpers, none on the production `ObjectStorageClient` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional warning logger for background storage operations; background time-index updates run best-effort and no longer block callers.
  * API to wait for/drain pending background writes before shutdown.

* **Tests**
  * Added thorough tests for timestamp utilities and thread activity indexing behavior (ordering, day-bucketing, non-blocking creation, failure handling).
  * Extended test helpers with controllable PUT failures/delays and key inspection utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/tegg/pull/445)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->