### PR TITLE
fix(agent-runtime): persist partial transcript when a run fails mid-turn

### DIFF
--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -192,7 +192,7 @@ export class AgentRuntime {
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
           if (task.committed) {
-            await this.persistMessagesOnAbort(threadId, input, streamMessages);
+            await this.persistPartialMessages(threadId, input, streamMessages);
           }
           await this.finaliseAbortedRun(run.id);
           const latest = await this.store.getRun(run.id);
@@ -209,7 +209,7 @@ export class AgentRuntime {
       const currentRun = await this.store.getRun(run.id);
       if (AgentRuntime.POST_LOOP_TERMINAL_STATUSES.has(currentRun.status)) {
         if (task.committed) {
-          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          await this.persistPartialMessages(threadId, input, streamMessages);
         }
         await this.finaliseAbortedRun(run.id);
         const latest = await this.store.getRun(run.id);
@@ -230,11 +230,17 @@ export class AgentRuntime {
     } catch (err: unknown) {
       if (abortController.signal.aborted) {
         if (task.committed) {
-          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          await this.persistPartialMessages(threadId, input, streamMessages);
         }
         await this.finaliseAbortedRun(run.id);
         const latest = await this.store.getRun(run.id);
         return RunBuilder.fromRecord(latest).snapshot();
+      }
+      // Non-abort failure (e.g. upstream stream terminated mid-turn). Persist
+      // the partial transcript so the thread history keeps the user turn and
+      // any committed assistant output instead of silently dropping the run.
+      if (task.committed) {
+        await this.persistPartialMessages(threadId, input, streamMessages);
       }
       try {
         await this.store.updateRun(run.id, rb.fail(err as Error));
@@ -282,7 +288,7 @@ export class AgentRuntime {
         for await (const msg of this.executor.execRun(input, abortController.signal)) {
           if (abortController.signal.aborted) {
             if (task.committed) {
-              await this.persistMessagesOnAbort(threadId, input, streamMessages);
+              await this.persistPartialMessages(threadId, input, streamMessages);
             }
             await this.finaliseAbortedRun(run.id);
             return;
@@ -310,6 +316,12 @@ export class AgentRuntime {
         await this.store.updateRun(run.id, rb.complete(usage));
       } catch (err: unknown) {
         if (!abortController.signal.aborted) {
+          // Non-abort failure (e.g. upstream stream terminated mid-turn).
+          // Persist the partial transcript before marking the run failed so
+          // the thread history is not silently dropped.
+          if (task.committed) {
+            await this.persistPartialMessages(threadId, input, streamMessages);
+          }
           try {
             const currentRun = await this.store.getRun(run.id);
             if (currentRun.status !== RunStatus.Cancelling && currentRun.status !== RunStatus.Cancelled) {
@@ -320,7 +332,7 @@ export class AgentRuntime {
           }
         } else {
           if (task.committed) {
-            await this.persistMessagesOnAbort(threadId, input, streamMessages);
+            await this.persistPartialMessages(threadId, input, streamMessages);
           }
           await this.finaliseAbortedRun(run.id);
           this.logger.error('[AgentRuntime] execRun error during abort:', err);
@@ -443,7 +455,7 @@ export class AgentRuntime {
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
           if (task.committed) {
-            await this.persistMessagesOnAbort(threadId, input, streamMessages);
+            await this.persistPartialMessages(threadId, input, streamMessages);
           }
           await this.finaliseAbortedRun(runId);
           this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
@@ -465,7 +477,7 @@ export class AgentRuntime {
       const currentRun = await this.store.getRun(runId);
       if (AgentRuntime.POST_LOOP_TERMINAL_STATUSES.has(currentRun.status)) {
         if (task.committed) {
-          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          await this.persistPartialMessages(threadId, input, streamMessages);
         }
         this.pushEvent(buffer, 'error', { message: currentRun.status, runId });
         return;
@@ -482,6 +494,12 @@ export class AgentRuntime {
       this.pushEvent(buffer, 'done', { result: 'success', runId });
     } catch (err: unknown) {
       if (!abortController.signal.aborted) {
+        // Non-abort failure (e.g. upstream stream terminated mid-turn).
+        // Persist the partial transcript before marking the run failed so the
+        // thread history is not silently dropped.
+        if (task.committed) {
+          await this.persistPartialMessages(threadId, input, streamMessages);
+        }
         try {
           const currentRun = await this.store.getRun(runId);
           if (currentRun.status !== RunStatus.Cancelling && currentRun.status !== RunStatus.Cancelled) {
@@ -493,7 +511,7 @@ export class AgentRuntime {
         this.pushEvent(buffer, 'error', { message: (err as Error).message, runId });
       } else {
         if (task.committed) {
-          await this.persistMessagesOnAbort(threadId, input, streamMessages);
+          await this.persistPartialMessages(threadId, input, streamMessages);
         }
         await this.finaliseAbortedRun(runId);
         this.logger.error('[AgentRuntime] execRun error during abort:', err);
@@ -578,21 +596,23 @@ export class AgentRuntime {
   }
 
   /**
-   * Persist input + collected stream messages to the thread when a run is
-   * aborted. Keeping the thread in sync with any partial state that the
-   * executor has already written (e.g. Claude CLI session file) is what
-   * allows subsequent resume requests to continue from a consistent history
-   * instead of diverging and failing at executor startup.
+   * Persist input + collected stream messages to the thread when a run ends
+   * on a non-success path — either an abort/cancel, or a mid-turn failure
+   * (e.g. the upstream stream is terminated). Keeping the thread in sync with
+   * any partial state that the executor has already written (e.g. Claude CLI
+   * session file) is what allows subsequent resume requests to continue from a
+   * consistent history instead of diverging and failing at executor startup,
+   * and prevents a failed turn from vanishing entirely from thread history.
    *
    * Callers must check `task.committed` before invoking this; if the
    * executor never reached a committed state the thread should be left
    * untouched so the next run starts fresh instead of trying to resume a
    * session that was never created on disk.
    *
-   * Errors are swallowed here so a store failure cannot mask the abort or
-   * prevent cancelRun from finalising the run status.
+   * Errors are swallowed here so a store failure cannot mask the original
+   * abort/failure or prevent the run status from being finalised.
    */
-  private async persistMessagesOnAbort(
+  private async persistPartialMessages(
     threadId: string,
     input: CreateRunInput,
     streamMessages: AgentMessage[],

--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -186,14 +186,22 @@ export class AgentRuntime {
     this.runningTasks.set(run.id, task);
 
     const streamMessages: AgentMessage[] = [];
+    // Persist a turn's transcript to the thread at most once, even if a later
+    // store call (e.g. updateRun) throws after a successful append and routes
+    // us through a catch-block persist. Guarded by task.committed so we never
+    // write a thread the executor has not persisted to its own session.
+    let messagesPersisted = false;
+    const persistPartialOnce = async (): Promise<void> => {
+      if (!task.committed || messagesPersisted) return;
+      messagesPersisted = true;
+      await this.persistPartialMessages(threadId, input, streamMessages);
+    };
     try {
       await this.store.updateRun(run.id, rb.start());
 
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
-          if (task.committed) {
-            await this.persistPartialMessages(threadId, input, streamMessages);
-          }
+          await persistPartialOnce();
           await this.finaliseAbortedRun(run.id);
           const latest = await this.store.getRun(run.id);
           return RunBuilder.fromRecord(latest).snapshot();
@@ -208,9 +216,7 @@ export class AgentRuntime {
       // terminal state instead of overwriting it with Completed.
       const currentRun = await this.store.getRun(run.id);
       if (AgentRuntime.POST_LOOP_TERMINAL_STATUSES.has(currentRun.status)) {
-        if (task.committed) {
-          await this.persistPartialMessages(threadId, input, streamMessages);
-        }
+        await persistPartialOnce();
         await this.finaliseAbortedRun(run.id);
         const latest = await this.store.getRun(run.id);
         return RunBuilder.fromRecord(latest).snapshot();
@@ -223,15 +229,14 @@ export class AgentRuntime {
         ...MessageConverter.toAgentMessages(input.input.messages),
         ...MessageConverter.filterForStorage(streamMessages),
       ]);
+      messagesPersisted = true;
 
       await this.store.updateRun(run.id, rb.complete(usage));
 
       return rb.snapshot();
     } catch (err: unknown) {
       if (abortController.signal.aborted) {
-        if (task.committed) {
-          await this.persistPartialMessages(threadId, input, streamMessages);
-        }
+        await persistPartialOnce();
         await this.finaliseAbortedRun(run.id);
         const latest = await this.store.getRun(run.id);
         return RunBuilder.fromRecord(latest).snapshot();
@@ -239,9 +244,8 @@ export class AgentRuntime {
       // Non-abort failure (e.g. upstream stream terminated mid-turn). Persist
       // the partial transcript so the thread history keeps the user turn and
       // any committed assistant output instead of silently dropping the run.
-      if (task.committed) {
-        await this.persistPartialMessages(threadId, input, streamMessages);
-      }
+      // No-op if the success path already appended (avoids duplicate history).
+      await persistPartialOnce();
       try {
         await this.store.updateRun(run.id, rb.fail(err as Error));
       } catch (storeErr) {
@@ -282,14 +286,19 @@ export class AgentRuntime {
 
     (async () => {
       const streamMessages: AgentMessage[] = [];
+      // Persist a turn's transcript to the thread at most once (see syncRun).
+      let messagesPersisted = false;
+      const persistPartialOnce = async (): Promise<void> => {
+        if (!task.committed || messagesPersisted) return;
+        messagesPersisted = true;
+        await this.persistPartialMessages(threadId, input, streamMessages);
+      };
       try {
         await this.store.updateRun(run.id, rb.start());
 
         for await (const msg of this.executor.execRun(input, abortController.signal)) {
           if (abortController.signal.aborted) {
-            if (task.committed) {
-              await this.persistPartialMessages(threadId, input, streamMessages);
-            }
+            await persistPartialOnce();
             await this.finaliseAbortedRun(run.id);
             return;
           }
@@ -302,6 +311,7 @@ export class AgentRuntime {
         // an external expiration) instead of overwriting it with Completed.
         const currentRun = await this.store.getRun(run.id);
         if (AgentRuntime.POST_LOOP_TERMINAL_STATUSES.has(currentRun.status)) {
+          await persistPartialOnce();
           return;
         }
 
@@ -312,16 +322,16 @@ export class AgentRuntime {
           ...MessageConverter.toAgentMessages(input.input.messages),
           ...MessageConverter.filterForStorage(streamMessages),
         ]);
+        messagesPersisted = true;
 
         await this.store.updateRun(run.id, rb.complete(usage));
       } catch (err: unknown) {
         if (!abortController.signal.aborted) {
           // Non-abort failure (e.g. upstream stream terminated mid-turn).
           // Persist the partial transcript before marking the run failed so
-          // the thread history is not silently dropped.
-          if (task.committed) {
-            await this.persistPartialMessages(threadId, input, streamMessages);
-          }
+          // the thread history is not silently dropped. No-op if the success
+          // path already appended (avoids duplicate history).
+          await persistPartialOnce();
           try {
             const currentRun = await this.store.getRun(run.id);
             if (currentRun.status !== RunStatus.Cancelling && currentRun.status !== RunStatus.Cancelled) {
@@ -331,9 +341,7 @@ export class AgentRuntime {
             this.logger.error('[AgentRuntime] failed to update run status after error:', storeErr);
           }
         } else {
-          if (task.committed) {
-            await this.persistPartialMessages(threadId, input, streamMessages);
-          }
+          await persistPartialOnce();
           await this.finaliseAbortedRun(run.id);
           this.logger.error('[AgentRuntime] execRun error during abort:', err);
         }
@@ -449,14 +457,19 @@ export class AgentRuntime {
   ): Promise<void> {
     const abortController = task.abortController;
     const streamMessages: AgentMessage[] = [];
+    // Persist a turn's transcript to the thread at most once (see syncRun).
+    let messagesPersisted = false;
+    const persistPartialOnce = async (): Promise<void> => {
+      if (!task.committed || messagesPersisted) return;
+      messagesPersisted = true;
+      await this.persistPartialMessages(threadId, input, streamMessages);
+    };
     try {
       await this.store.updateRun(runId, rb.start());
 
       for await (const msg of this.executor.execRun(input, abortController.signal)) {
         if (abortController.signal.aborted) {
-          if (task.committed) {
-            await this.persistPartialMessages(threadId, input, streamMessages);
-          }
+          await persistPartialOnce();
           await this.finaliseAbortedRun(runId);
           this.pushEvent(buffer, 'error', { message: 'cancelled', runId });
           return;
@@ -476,9 +489,7 @@ export class AgentRuntime {
       // an external expiration) instead of overwriting it with Completed.
       const currentRun = await this.store.getRun(runId);
       if (AgentRuntime.POST_LOOP_TERMINAL_STATUSES.has(currentRun.status)) {
-        if (task.committed) {
-          await this.persistPartialMessages(threadId, input, streamMessages);
-        }
+        await persistPartialOnce();
         this.pushEvent(buffer, 'error', { message: currentRun.status, runId });
         return;
       }
@@ -489,6 +500,7 @@ export class AgentRuntime {
         ...MessageConverter.toAgentMessages(input.input.messages),
         ...MessageConverter.filterForStorage(streamMessages),
       ]);
+      messagesPersisted = true;
       await this.store.updateRun(runId, rb.complete(usage));
 
       this.pushEvent(buffer, 'done', { result: 'success', runId });
@@ -496,10 +508,9 @@ export class AgentRuntime {
       if (!abortController.signal.aborted) {
         // Non-abort failure (e.g. upstream stream terminated mid-turn).
         // Persist the partial transcript before marking the run failed so the
-        // thread history is not silently dropped.
-        if (task.committed) {
-          await this.persistPartialMessages(threadId, input, streamMessages);
-        }
+        // thread history is not silently dropped. No-op if the success path
+        // already appended (avoids duplicate history).
+        await persistPartialOnce();
         try {
           const currentRun = await this.store.getRun(runId);
           if (currentRun.status !== RunStatus.Cancelling && currentRun.status !== RunStatus.Cancelled) {
@@ -510,9 +521,7 @@ export class AgentRuntime {
         }
         this.pushEvent(buffer, 'error', { message: (err as Error).message, runId });
       } else {
-        if (task.committed) {
-          await this.persistPartialMessages(threadId, input, streamMessages);
-        }
+        await persistPartialOnce();
         await this.finaliseAbortedRun(runId);
         this.logger.error('[AgentRuntime] execRun error during abort:', err);
         this.pushEvent(buffer, 'error', { message: 'cancelled', runId });

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -340,6 +340,40 @@ describe('test/AgentRuntime.test.ts', () => {
       assert.equal(persisted.messages[0].type, 'user');
       assert.equal(persisted.messages[1].type, 'assistant');
     });
+
+    it('should not duplicate thread messages when updateRun fails after a successful append', async () => {
+      const thread = await runtime.createThread();
+      // Executor finishes normally (commits), so the success path appends, then
+      // the completing updateRun throws — routing into the catch block.
+      executor.execRun = async function* (): AsyncGenerator<AgentMessage> {
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] } };
+        yield {
+          type: 'result',
+          subtype: 'success',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        } as SDKResultMessage;
+      };
+      // Fail the 2nd updateRun (1=rb.start, 2=rb.complete) — i.e. right after
+      // the success-path appendMessages has already written the transcript.
+      let calls = 0;
+      const origUpdateRun = store.updateRun.bind(store);
+      store.updateRun = async (runId: string, updates: Partial<RunRecord>) => {
+        calls++;
+        if (calls === 2) throw new Error('updateRun failed');
+        return origUpdateRun(runId, updates);
+      };
+
+      await assert.rejects(
+        () => runtime.syncRun({ threadId: thread.id, input: { messages: [{ role: 'user', content: 'Hi' }] } }),
+      );
+
+      // Messages must be appended exactly once — the catch-block persist must be
+      // a no-op because the success path already persisted (no duplicate history).
+      const persisted = await store.getThread(thread.id);
+      assert.equal(persisted.messages.length, 2);
+      assert.equal(persisted.messages[0].type, 'user');
+      assert.equal(persisted.messages[1].type, 'assistant');
+    });
   });
 
   describe('asyncRun', () => {

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -317,6 +317,29 @@ describe('test/AgentRuntime.test.ts', () => {
         },
       );
     });
+
+    it('should persist the partial transcript and mark Failed when execRun throws after committing', async () => {
+      const thread = await runtime.createThread();
+      executor.execRun = async function* (): AsyncGenerator<AgentMessage> {
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } };
+        throw new Error('stream terminated');
+      };
+
+      await assert.rejects(
+        () => runtime.syncRun({ threadId: thread.id, input: { messages: [{ role: 'user', content: 'Hi' }] } }),
+        (err: unknown) => {
+          assert(err instanceof Error);
+          assert.equal(err.message, 'stream terminated');
+          return true;
+        },
+      );
+
+      // The failed turn must not vanish: user + committed assistant are persisted.
+      const persisted = await store.getThread(thread.id);
+      assert.equal(persisted.messages.length, 2);
+      assert.equal(persisted.messages[0].type, 'user');
+      assert.equal(persisted.messages[1].type, 'assistant');
+    });
   });
 
   describe('asyncRun', () => {
@@ -368,6 +391,24 @@ describe('test/AgentRuntime.test.ts', () => {
 
       const run = await store.getRun(result.id);
       assert.deepStrictEqual(run.metadata, meta);
+    });
+
+    it('should persist the partial transcript and mark Failed when execRun throws after committing', async () => {
+      executor.execRun = async function* (): AsyncGenerator<AgentMessage> {
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } };
+        throw new Error('stream terminated');
+      };
+
+      const result = await runtime.asyncRun({ input: { messages: [{ role: 'user', content: 'Hi' }] } });
+      await runtime.waitForPendingTasks();
+
+      const run = await store.getRun(result.id);
+      assert.equal(run.status, RunStatus.Failed);
+
+      const thread = await store.getThread(result.threadId!);
+      assert.equal(thread.messages.length, 2);
+      assert.equal(thread.messages[0].type, 'user');
+      assert.equal(thread.messages[1].type, 'assistant');
     });
   });
 
@@ -524,6 +565,29 @@ describe('test/AgentRuntime.test.ts', () => {
       const runId = (runCreatedEvent.data as any).runId;
       const run = await runtime.getRun(runId);
       assert.equal(run.status, RunStatus.Failed);
+    });
+
+    it('should persist the partial transcript when execRun throws after committing', async () => {
+      executor.execRun = async function* (): AsyncGenerator<AgentMessage> {
+        yield { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] } };
+        throw new Error('stream terminated');
+      };
+
+      const writer = new MockSSEWriter();
+      await runtime.streamRun({ input: { messages: [{ role: 'user', content: 'Hi' }] } }, writer);
+
+      const runCreatedEvent = writer.events[0].data as StreamEvent;
+      const runId = (runCreatedEvent.data as any).runId;
+      const threadId = (runCreatedEvent.data as any).threadId;
+
+      const run = await runtime.getRun(runId);
+      assert.equal(run.status, RunStatus.Failed);
+
+      // The failed turn must not vanish from thread history.
+      const thread = await runtime.getThread(threadId);
+      assert.equal(thread.messages.length, 2);
+      assert.equal(thread.messages[0].type, 'user');
+      assert.equal(thread.messages[1].type, 'assistant');
     });
 
     it('should persist usage to store on completion', async () => {


### PR DESCRIPTION
## Problem

When the executor's `execRun()` async generator throws part-way through a turn for a **non-abort** reason — most commonly the upstream model stream being terminated (`API Error: terminated`) — the run's user prompt and any already-generated assistant output were **never written to the thread store**.

Root cause: `messages.jsonl` is only written by `store.appendMessages()`, which is only reached on the **success** path of each execution method. In the `catch` blocks, the *abort* branch already had a fallback persist (`persistMessagesOnAbort`, guarded by `task.committed`), but the **non-abort error** branch only called `updateRun(rb.fail)` and pushed an `error` event — it never persisted anything.

Result: the failed turn vanishes from `messages.jsonl` entirely. The client sees the error, but the persisted history skips straight from the previous turn to the next one, leaving storage inconsistent with what actually happened and unusable for resume / audit.

## Fix

All three execution paths — `syncRun`, `asyncRun`, and `executeStreamBackground` — now persist the partial transcript in their non-abort error branch, **before** marking the run failed. This mirrors the existing abort fallback and reuses the same `task.committed` guard, so we never write a thread for a session the executor never persisted to disk (which would break subsequent resume).

`persistMessagesOnAbort` is renamed to `persistPartialMessages` since it now serves both the abort and the mid-turn-failure paths; its doc comment is generalized accordingly. Behavior of the method body is unchanged (append input messages + `filterForStorage(streamMessages)`, swallow store errors).

Because token-level deltas are `stream_event` messages (filtered out by `filterForStorage`), a mid-stream `tool_use` that never completed is *not* present in `streamMessages`, so this cannot persist an unterminated/half tool_use block.

## Tests

Added one regression test per execution path (`syncRun` / `asyncRun` / `streamRun`): yield one assistant message (flipping `committed=true`), then throw, and assert the run is `Failed` **and** the thread retains both the user and the assistant message.

All existing tests pass (158 passing). Note: 2 pre-existing failures in `cancelRun` (`AgentTimeoutError is not a constructor`) are present on `master` as well and are unrelated to this change (local ts-node type-resolution of `@eggjs/tegg-types`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation history is more robust during non-success runs: committed assistant responses are preserved and persisted on failures, aborts, or mid-turn errors, and duplicate messages are avoided.

* **Tests**
  * Added runtime tests verifying partial transcripts are persisted and not duplicated when execution fails after committing output in sync, async, and streaming runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->