### PR TITLE
feat: add mcp request unit test helper

### DIFF
--- a/core/mcp-client/package.json
+++ b/core/mcp-client/package.json
@@ -15,7 +15,7 @@
     "tegg"
   ],
   "scripts": {
-    "test": "cross-env NODE_ENV=test NODE_OPTIONS='--no-deprecation' mocha --require ts-node/register --require source-map-support/register",
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS='--no-deprecation' mocha --no-config --timeout 120000 --exit test/**/*.test.cjs",
     "clean": "tsc -b --clean",
     "tsc": "npm run clean && tsc -p ./tsconfig.json",
     "tsc:pub": "npm run clean && tsc -p ./tsconfig.pub.json",

--- a/core/mcp-client/package.json
+++ b/core/mcp-client/package.json
@@ -15,7 +15,7 @@
     "tegg"
   ],
   "scripts": {
-    "test": "cross-env NODE_ENV=test NODE_OPTIONS='--no-deprecation' mocha",
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS='--no-deprecation' mocha --require ts-node/register --require source-map-support/register",
     "clean": "tsc -b --clean",
     "tsc": "npm run clean && tsc -p ./tsconfig.json",
     "tsc:pub": "npm run clean && tsc -p ./tsconfig.pub.json",

--- a/core/mcp-client/package.json
+++ b/core/mcp-client/package.json
@@ -49,6 +49,7 @@
     "@types/node": "^20.2.4",
     "cross-env": "^7.0.3",
     "mocha": "^10.2.0",
+    "source-map-support": "^0.5.16",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },

--- a/core/mcp-client/src/HttpMCPClient.ts
+++ b/core/mcp-client/src/HttpMCPClient.ts
@@ -6,7 +6,14 @@ import { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { fetch } from 'urllib';
 import { mergeHeaders } from './HeaderUtil';
 import type { Logger } from '@eggjs/tegg';
-import { loadMcpTools } from '@langchain/mcp-adapters';
+
+type McpAdaptersModule = typeof import('@langchain/mcp-adapters');
+
+// eslint-disable-next-line no-new-func -- preserve native import() in CJS output
+const importMcpAdapters = new Function('specifier', 'return import(specifier)') as (
+  specifier: string
+) => Promise<McpAdaptersModule>;
+
 export interface BaseHttpClientOptions extends ClientOptions {
   logger: Logger;
   fetch?: typeof fetch;
@@ -117,6 +124,7 @@ export class HttpMCPClient extends Client {
     await this.connect(this.#transport, this.options.requestOptions);
   }
   async getLangChainTool() {
+    const { loadMcpTools } = await importMcpAdapters('@langchain/mcp-adapters');
     return await loadMcpTools(this.clientInfo.name, this as any, {
       throwOnLoadError: true,
       prefixToolNameWithServerName: false,

--- a/core/mcp-client/test/HttpMCPClient.test.cjs
+++ b/core/mcp-client/test/HttpMCPClient.test.cjs
@@ -1,0 +1,3 @@
+require('ts-node/register');
+require('source-map-support/register');
+require('./HttpMCPClient.test.ts');

--- a/core/mcp-client/test/HttpMCPClient.test.ts
+++ b/core/mcp-client/test/HttpMCPClient.test.ts
@@ -1,19 +1,10 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
-import fs from 'node:fs';
 import { createRequire } from 'node:module';
-import path from 'node:path';
 const majorVersion = parseInt(process.versions.node.split('.')[0], 10);
 
 function createTestRequire() {
-  const cwdPackagePath = path.join(process.cwd(), 'package.json');
-  if (fs.existsSync(cwdPackagePath)) {
-    const cwdPackage = JSON.parse(fs.readFileSync(cwdPackagePath, 'utf8'));
-    if (cwdPackage.name === '@eggjs/mcp-client') {
-      return createRequire(path.join(process.cwd(), 'test/HttpMCPClient.test.ts'));
-    }
-  }
-  return createRequire(path.join(process.cwd(), 'core/mcp-client/test/HttpMCPClient.test.ts'));
+  return createRequire(__filename);
 }
 
 describe('test/HttpMCPClient.test.ts', () => {

--- a/core/mcp-client/test/HttpMCPClient.test.ts
+++ b/core/mcp-client/test/HttpMCPClient.test.ts
@@ -1,17 +1,30 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 const majorVersion = parseInt(process.versions.node.split('.')[0], 10);
+
+function createTestRequire() {
+  const cwdPackagePath = path.join(process.cwd(), 'package.json');
+  if (fs.existsSync(cwdPackagePath)) {
+    const cwdPackage = JSON.parse(fs.readFileSync(cwdPackagePath, 'utf8'));
+    if (cwdPackage.name === '@eggjs/mcp-client') {
+      return createRequire(path.join(process.cwd(), 'test/HttpMCPClient.test.ts'));
+    }
+  }
+  return createRequire(path.join(process.cwd(), 'core/mcp-client/test/HttpMCPClient.test.ts'));
+}
 
 describe('test/HttpMCPClient.test.ts', () => {
   if (majorVersion < 18) {
     return;
   }
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { HttpMCPClient } = require('../src/HttpMCPClient');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { startSSEServer, stopSSEServer } = require('./fixtures/sse-mcp-server/http');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { startStreamableServer, stopStreamableServer } = require('./fixtures/streamable-mcp-server/http');
+  const requireModule = createTestRequire();
+  const { HttpMCPClient } = requireModule('../src/HttpMCPClient') as typeof import('../src/HttpMCPClient');
+  const { startSSEServer, stopSSEServer } = requireModule('./fixtures/sse-mcp-server/http') as typeof import('./fixtures/sse-mcp-server/http');
+  const { startStreamableServer, stopStreamableServer } = requireModule('./fixtures/streamable-mcp-server/http') as typeof import('./fixtures/streamable-mcp-server/http');
+
   it('should work', async () => {
     await startStreamableServer();
     const client = new HttpMCPClient({
@@ -22,11 +35,16 @@ describe('test/HttpMCPClient.test.ts', () => {
       logger: console as any,
       url: 'http://127.0.0.1:17243',
     });
-    await client.init();
-    const tools = await client.listTools();
-    assert(tools);
-    await stopStreamableServer();
+    try {
+      await client.init();
+      const tools = await client.listTools();
+      assert(tools);
+    } finally {
+      await client.close();
+      await stopStreamableServer();
+    }
   });
+
   it('should sse work', async () => {
     await startSSEServer();
     const client = new HttpMCPClient({
@@ -45,9 +63,13 @@ describe('test/HttpMCPClient.test.ts', () => {
       },
       url: 'http://127.0.0.1:17233/mcp/sse',
     });
-    await client.init();
-    const tools = await client.listTools();
-    assert(tools);
-    await stopSSEServer();
+    try {
+      await client.init();
+      const tools = await client.listTools();
+      assert(tools);
+    } finally {
+      await client.close();
+      await stopSSEServer();
+    }
   });
 });

--- a/core/mcp-client/test/fixtures/sse-mcp-server/http.ts
+++ b/core/mcp-client/test/fixtures/sse-mcp-server/http.ts
@@ -38,9 +38,9 @@ server.registerResource(
 const transports = {};
 export const headers = {};
 
-export let httpServer;
+export let httpServer: http.Server | undefined;
 export async function startSSEServer(port = 17233) {
-  const httpServer = http.createServer(async (req, res) => {
+  httpServer = http.createServer(async (req, res) => {
     const url = new URL(`http://127.0.0.1:${port}${req.url!}`);
     const headerKey = `${req.method}${url.pathname}`;
     const serverCode = req.headers['x-mcp-server-code'] as string;
@@ -65,11 +65,26 @@ export async function startSSEServer(port = 17233) {
       res.end();
     }
   });
+  const serverToListen = httpServer;
   return new Promise<void>(resolve => {
-    httpServer.listen(port, resolve);
+    serverToListen.listen(port, resolve);
   });
 }
 
 export async function stopSSEServer() {
-  server.close();
+  await Promise.resolve(server.close()).catch(() => undefined);
+  if (!httpServer) {
+    return;
+  }
+  const serverToClose = httpServer;
+  httpServer = undefined;
+  await new Promise<void>((resolve, reject) => {
+    serverToClose.close(err => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
 }

--- a/core/mcp-client/test/fixtures/sse-mcp-server/http.ts
+++ b/core/mcp-client/test/fixtures/sse-mcp-server/http.ts
@@ -66,8 +66,17 @@ export async function startSSEServer(port = 17233) {
     }
   });
   const serverToListen = httpServer;
-  return new Promise<void>(resolve => {
-    serverToListen.listen(port, resolve);
+  return new Promise<void>((resolve, reject) => {
+    function onError(err: Error) {
+      serverToListen.removeListener('listening', onListening);
+      reject(err);
+    }
+    function onListening() {
+      serverToListen.removeListener('error', onError);
+      resolve();
+    }
+    serverToListen.once('error', onError);
+    serverToListen.listen(port, onListening);
   });
 }
 

--- a/core/mcp-client/test/fixtures/streamable-mcp-server/http.ts
+++ b/core/mcp-client/test/fixtures/streamable-mcp-server/http.ts
@@ -86,8 +86,17 @@ export async function startStreamableServer(port = 17243){
     }
   });
   const serverToListen = httpServer;
-  return new Promise<void>(resolve => {
-    serverToListen.listen(port, resolve);
+  return new Promise<void>((resolve, reject) => {
+    function onError(err: Error) {
+      serverToListen.removeListener('listening', onListening);
+      reject(err);
+    }
+    function onListening() {
+      serverToListen.removeListener('error', onError);
+      resolve();
+    }
+    serverToListen.once('error', onError);
+    serverToListen.listen(port, onListening);
   });
 }
 

--- a/core/mcp-client/test/fixtures/streamable-mcp-server/http.ts
+++ b/core/mcp-client/test/fixtures/streamable-mcp-server/http.ts
@@ -35,9 +35,9 @@ server.registerResource(
 
 export const headers = {};
 
-export let httpServer;
+export let httpServer: http.Server | undefined;
 export async function startStreamableServer(port = 17243){
-  const httpServer = http.createServer(async (req, res) => {
+  httpServer = http.createServer(async (req, res) => {
     const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
     const url = new URL(`http://127.0.0.1:${port}${req.url!}`);
     const headerKey = `${req.method}${url.pathname}`;
@@ -85,11 +85,26 @@ export async function startStreamableServer(port = 17243){
       }));
     }
   });
+  const serverToListen = httpServer;
   return new Promise<void>(resolve => {
-    httpServer.listen(port, resolve);
+    serverToListen.listen(port, resolve);
   });
 }
 
 export async function stopStreamableServer() {
-  server.close();
+  await Promise.resolve(server.close()).catch(() => undefined);
+  if (!httpServer) {
+    return;
+  }
+  const serverToClose = httpServer;
+  httpServer = undefined;
+  await new Promise<void>((resolve, reject) => {
+    serverToClose.close(err => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
 }

--- a/plugin/controller/app/extend/application.ts
+++ b/plugin/controller/app/extend/application.ts
@@ -1,0 +1,19 @@
+import type { Application } from 'egg';
+import type MCPRequestUnitTest from '../../lib/impl/mcp/MCPRequestUnitTest';
+import type { MCPRequestMockApplication } from '../../lib/impl/mcp/MCPRequestUnitTest';
+
+export default {
+  mcpRequest(this: Application, name?: string): MCPRequestUnitTest {
+    const majorVersion = parseInt(process.versions.node.split('.')[0], 10);
+    if (majorVersion < 18) {
+      throw new Error('app.mcpRequest() requires Node.js >= 18.');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const RequestUnitTest = require('../../lib/impl/mcp/MCPRequestUnitTest').default as typeof import('../../lib/impl/mcp/MCPRequestUnitTest').default;
+    return new RequestUnitTest({
+      app: this as MCPRequestMockApplication,
+      serverName: name,
+    });
+  },
+};

--- a/plugin/controller/lib/impl/mcp/MCPRequestUnitTest.ts
+++ b/plugin/controller/lib/impl/mcp/MCPRequestUnitTest.ts
@@ -23,12 +23,7 @@ import { MCPControllerRegister } from './MCPControllerRegister';
 
 export type MCPTransportProtocol = 'streamable' | 'stateless' | 'sse';
 
-export interface MCPRequestMockApplication extends Application {
-  httpRequest(): {
-    get(url: string): { url: string };
-    post(url: string): { url: string };
-  };
-}
+export type MCPRequestMockApplication = Application;
 
 export interface MCPRequestUnitTestOptions {
   app: MCPRequestMockApplication;
@@ -143,7 +138,7 @@ export default class MCPRequestUnitTest {
   #sseTransportOptions?: SSEClientTransportOptions;
 
   constructor(options: MCPRequestUnitTestOptions) {
-    assert(options.app, '初始化依赖 app');
+    assert(options.app, 'options.app is required to initialize MCPRequestUnitTest');
     this.#app = options.app;
     this.#serverName = options.serverName;
   }
@@ -189,7 +184,8 @@ export default class MCPRequestUnitTest {
     return this;
   }
 
-  headers(headers: Record<string, string | number | boolean | undefined>) {
+  headers(headers?: Record<string, string | number | boolean | undefined> | null) {
+    if (!headers) return this;
     for (const [ key, value ] of Object.entries(headers)) {
       if (value !== undefined) {
         this.set(key, value);
@@ -203,6 +199,7 @@ export default class MCPRequestUnitTest {
       options?.clientInfo ?? this.#clientInfo,
       options?.clientOptions ?? this.#clientOptions,
     );
+    await this.#ensureServerListening();
     const transport = this.#createTransport(options);
     await client.connect(transport);
     return new MCPTestClient(client, transport, this.#protocol);
@@ -252,11 +249,30 @@ export default class MCPRequestUnitTest {
 
   async #withClient<T>(callback: (client: MCPTestClient) => Promise<T>): Promise<T> {
     const client = await this.connect();
+    let hasCallbackError = false;
+    let callbackError: unknown;
+    let result: T | undefined;
     try {
-      return await callback(client);
-    } finally {
-      await client.close();
+      result = await callback(client);
+    } catch (err) {
+      hasCallbackError = true;
+      callbackError = err;
     }
+
+    try {
+      await client.close();
+    } catch (closeError) {
+      if (hasCallbackError) {
+        this.#app.logger?.error('Failed to close MCP test client:', closeError);
+      } else {
+        throw closeError;
+      }
+    }
+
+    if (hasCallbackError) {
+      throw callbackError;
+    }
+    return result as T;
   }
 
   #createTransport(options?: MCPConnectOptions) {
@@ -275,6 +291,25 @@ export default class MCPRequestUnitTest {
       authProvider: this.#createAuthProvider(),
       ...transportOptions,
       requestInit: this.#mergeRequestInit(transportOptions.requestInit),
+    });
+  }
+
+  async #ensureServerListening() {
+    const server = (this.#app as any).server;
+    if (!server || server.listening) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      function onError(err: Error) {
+        server.removeListener('listening', onListening);
+        reject(err);
+      }
+      function onListening() {
+        server.removeListener('error', onError);
+        resolve();
+      }
+      server.once('error', onError);
+      server.listen(0, onListening);
     });
   }
 
@@ -319,8 +354,12 @@ export default class MCPRequestUnitTest {
 
   get #url() {
     const path = this.#path;
-    const method = this.#protocol === 'sse' ? 'get' : 'post';
-    return this.#app.httpRequest()[method](path).url;
+    const server = (this.#app as any).server;
+    const address = server?.address();
+    const port = address && typeof address !== 'string' ? address.port : null;
+    assert(port, 'app server must be listening before creating MCP request URL');
+    const host = `http://127.0.0.1:${port}`;
+    return new URL(path, host).toString();
   }
 
   get #path() {

--- a/plugin/controller/lib/impl/mcp/MCPRequestUnitTest.ts
+++ b/plugin/controller/lib/impl/mcp/MCPRequestUnitTest.ts
@@ -289,9 +289,9 @@ export default class MCPRequestUnitTest {
           token_type: 'Bearer',
         };
       },
-      saveTokens: () => {},
-      redirectToAuthorization: () => {},
-      saveCodeVerifier: () => {},
+      saveTokens: () => undefined,
+      redirectToAuthorization: () => undefined,
+      saveCodeVerifier: () => undefined,
       codeVerifier: () => '',
     };
   }

--- a/plugin/controller/lib/impl/mcp/MCPRequestUnitTest.ts
+++ b/plugin/controller/lib/impl/mcp/MCPRequestUnitTest.ts
@@ -1,0 +1,358 @@
+import assert from 'node:assert';
+import { Client, type ClientOptions } from '@modelcontextprotocol/sdk/client/index.js';
+import {
+  SSEClientTransport,
+  type SSEClientTransportOptions,
+} from '@modelcontextprotocol/sdk/client/sse.js';
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type {
+  CallToolRequest,
+  GetPromptRequest,
+  Implementation,
+  ListPromptsRequest,
+  ListResourceTemplatesRequest,
+  ListResourcesRequest,
+  ListToolsRequest,
+  ReadResourceRequest,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Application } from 'egg';
+import { MCPControllerRegister } from './MCPControllerRegister';
+
+export type MCPTransportProtocol = 'streamable' | 'stateless' | 'sse';
+
+export interface MCPRequestMockApplication extends Application {
+  httpRequest(): {
+    get(url: string): { url: string };
+    post(url: string): { url: string };
+  };
+}
+
+export interface MCPRequestUnitTestOptions {
+  app: MCPRequestMockApplication;
+  serverName?: string;
+}
+
+export interface MCPConnectOptions {
+  clientInfo?: Implementation;
+  clientOptions?: ClientOptions;
+  streamableTransportOptions?: StreamableHTTPClientTransportOptions;
+  sseTransportOptions?: SSEClientTransportOptions;
+}
+
+type RequestOptions = Parameters<Client['request']>[2];
+type HeadersRecord = Record<string, string>;
+
+export class MCPTestClient {
+  readonly client: Client;
+  readonly transport: StreamableHTTPClientTransport | SSEClientTransport;
+  readonly protocol: MCPTransportProtocol;
+
+  constructor(
+    client: Client,
+    transport: StreamableHTTPClientTransport | SSEClientTransport,
+    protocol: MCPTransportProtocol,
+  ) {
+    this.client = client;
+    this.transport = transport;
+    this.protocol = protocol;
+  }
+
+  listTools(params?: ListToolsRequest['params'], options?: RequestOptions) {
+    return this.client.listTools(params, options);
+  }
+
+  listResources(params?: ListResourcesRequest['params'], options?: RequestOptions) {
+    return this.client.listResources(params, options);
+  }
+
+  listResourceTemplates(params?: ListResourceTemplatesRequest['params'], options?: RequestOptions) {
+    return this.client.listResourceTemplates(params, options);
+  }
+
+  listPrompts(params?: ListPromptsRequest['params'], options?: RequestOptions) {
+    return this.client.listPrompts(params, options);
+  }
+
+  callTool(name: string, args?: Record<string, unknown>, options?: RequestOptions): ReturnType<Client['callTool']>;
+  callTool(params: CallToolRequest['params'], options?: RequestOptions): ReturnType<Client['callTool']>;
+  callTool(
+    nameOrParams: string | CallToolRequest['params'],
+    argsOrOptions?: Record<string, unknown> | RequestOptions,
+    options?: RequestOptions,
+  ) {
+    const params = typeof nameOrParams === 'string' ?
+      { name: nameOrParams, arguments: argsOrOptions as Record<string, unknown> | undefined ?? {} } :
+      nameOrParams;
+    const requestOptions = typeof nameOrParams === 'string' ? options : argsOrOptions as RequestOptions | undefined;
+    return this.client.callTool(params, undefined, requestOptions);
+  }
+
+  readResource(uri: string, options?: RequestOptions): ReturnType<Client['readResource']>;
+  readResource(params: ReadResourceRequest['params'], options?: RequestOptions): ReturnType<Client['readResource']>;
+  readResource(uriOrParams: string | ReadResourceRequest['params'], options?: RequestOptions) {
+    const params = typeof uriOrParams === 'string' ? { uri: uriOrParams } : uriOrParams;
+    return this.client.readResource(params, options);
+  }
+
+  getPrompt(name: string, args?: Record<string, string>, options?: RequestOptions): ReturnType<Client['getPrompt']>;
+  getPrompt(params: GetPromptRequest['params'], options?: RequestOptions): ReturnType<Client['getPrompt']>;
+  getPrompt(
+    nameOrParams: string | GetPromptRequest['params'],
+    argsOrOptions?: Record<string, string> | RequestOptions,
+    options?: RequestOptions,
+  ) {
+    const params = typeof nameOrParams === 'string' ?
+      { name: nameOrParams, arguments: argsOrOptions as Record<string, string> | undefined ?? {} } :
+      nameOrParams;
+    const requestOptions = typeof nameOrParams === 'string' ? options : argsOrOptions as RequestOptions | undefined;
+    return this.client.getPrompt(params, requestOptions);
+  }
+
+  request(...args: Parameters<Client['request']>) {
+    return this.client.request(...args);
+  }
+
+  setNotificationHandler(...args: Parameters<Client['setNotificationHandler']>) {
+    this.client.setNotificationHandler(...args);
+    return this;
+  }
+
+  async close() {
+    if (this.transport instanceof StreamableHTTPClientTransport) {
+      await this.transport.terminateSession();
+    }
+    await this.client.close();
+  }
+}
+
+export default class MCPRequestUnitTest {
+  readonly #app: MCPRequestMockApplication;
+  #protocol: MCPTransportProtocol = 'streamable';
+  #serverName?: string;
+  #headers: HeadersRecord = {};
+  #authToken = 'akita';
+  #clientInfo: Implementation = {
+    name: 'egg-mcp-test-client',
+    version: '1.0.0',
+  };
+  #clientOptions?: ClientOptions;
+  #streamableTransportOptions?: StreamableHTTPClientTransportOptions;
+  #sseTransportOptions?: SSEClientTransportOptions;
+
+  constructor(options: MCPRequestUnitTestOptions) {
+    assert(options.app, '初始化依赖 app');
+    this.#app = options.app;
+    this.#serverName = options.serverName;
+  }
+
+  streamable(options?: StreamableHTTPClientTransportOptions) {
+    this.#protocol = 'streamable';
+    this.#streamableTransportOptions = options;
+    return this;
+  }
+
+  stateless(options?: StreamableHTTPClientTransportOptions) {
+    this.#protocol = 'stateless';
+    this.#streamableTransportOptions = options;
+    return this;
+  }
+
+  sse(options?: SSEClientTransportOptions) {
+    this.#protocol = 'sse';
+    this.#sseTransportOptions = options;
+    return this;
+  }
+
+  authToken(token: string) {
+    this.#authToken = token;
+    return this;
+  }
+
+  clientInfo(info: Partial<Implementation>) {
+    this.#clientInfo = {
+      ...this.#clientInfo,
+      ...info,
+    };
+    return this;
+  }
+
+  clientOptions(options: ClientOptions) {
+    this.#clientOptions = options;
+    return this;
+  }
+
+  set(name: string, value: string | number | boolean) {
+    this.#headers[name] = String(value);
+    return this;
+  }
+
+  headers(headers: Record<string, string | number | boolean | undefined>) {
+    for (const [ key, value ] of Object.entries(headers)) {
+      if (value !== undefined) {
+        this.set(key, value);
+      }
+    }
+    return this;
+  }
+
+  async connect(options?: MCPConnectOptions) {
+    const client = new Client(
+      options?.clientInfo ?? this.#clientInfo,
+      options?.clientOptions ?? this.#clientOptions,
+    );
+    const transport = this.#createTransport(options);
+    await client.connect(transport);
+    return new MCPTestClient(client, transport, this.#protocol);
+  }
+
+  listTools(params?: ListToolsRequest['params'], options?: RequestOptions) {
+    return this.#withClient(client => client.listTools(params, options));
+  }
+
+  listResources(params?: ListResourcesRequest['params'], options?: RequestOptions) {
+    return this.#withClient(client => client.listResources(params, options));
+  }
+
+  listResourceTemplates(params?: ListResourceTemplatesRequest['params'], options?: RequestOptions) {
+    return this.#withClient(client => client.listResourceTemplates(params, options));
+  }
+
+  listPrompts(params?: ListPromptsRequest['params'], options?: RequestOptions) {
+    return this.#withClient(client => client.listPrompts(params, options));
+  }
+
+  callTool(name: string, args?: Record<string, unknown>, options?: RequestOptions): ReturnType<Client['callTool']>;
+  callTool(params: CallToolRequest['params'], options?: RequestOptions): ReturnType<Client['callTool']>;
+  callTool(
+    nameOrParams: string | CallToolRequest['params'],
+    argsOrOptions?: Record<string, unknown> | RequestOptions,
+    options?: RequestOptions,
+  ) {
+    return this.#withClient(client => client.callTool(nameOrParams as any, argsOrOptions as any, options));
+  }
+
+  readResource(uri: string, options?: RequestOptions): ReturnType<Client['readResource']>;
+  readResource(params: ReadResourceRequest['params'], options?: RequestOptions): ReturnType<Client['readResource']>;
+  readResource(uriOrParams: string | ReadResourceRequest['params'], options?: RequestOptions) {
+    return this.#withClient(client => client.readResource(uriOrParams as any, options));
+  }
+
+  getPrompt(name: string, args?: Record<string, string>, options?: RequestOptions): ReturnType<Client['getPrompt']>;
+  getPrompt(params: GetPromptRequest['params'], options?: RequestOptions): ReturnType<Client['getPrompt']>;
+  getPrompt(
+    nameOrParams: string | GetPromptRequest['params'],
+    argsOrOptions?: Record<string, string> | RequestOptions,
+    options?: RequestOptions,
+  ) {
+    return this.#withClient(client => client.getPrompt(nameOrParams as any, argsOrOptions as any, options));
+  }
+
+  async #withClient<T>(callback: (client: MCPTestClient) => Promise<T>): Promise<T> {
+    const client = await this.connect();
+    try {
+      return await callback(client);
+    } finally {
+      await client.close();
+    }
+  }
+
+  #createTransport(options?: MCPConnectOptions) {
+    const url = new URL(this.#url);
+    if (this.#protocol === 'sse') {
+      const transportOptions = options?.sseTransportOptions ?? this.#sseTransportOptions ?? {};
+      return new SSEClientTransport(url, {
+        authProvider: this.#createAuthProvider(),
+        ...transportOptions,
+        requestInit: this.#mergeRequestInit(transportOptions.requestInit),
+      });
+    }
+
+    const transportOptions = options?.streamableTransportOptions ?? this.#streamableTransportOptions ?? {};
+    return new StreamableHTTPClientTransport(url, {
+      authProvider: this.#createAuthProvider(),
+      ...transportOptions,
+      requestInit: this.#mergeRequestInit(transportOptions.requestInit),
+    });
+  }
+
+  #createAuthProvider(): NonNullable<StreamableHTTPClientTransportOptions['authProvider']> {
+    return {
+      get redirectUrl() { return 'http://localhost/callback'; },
+      get clientMetadata() { return { redirect_uris: [ 'http://localhost/callback' ] }; },
+      clientInformation: () => ({ client_id: 'test-client-id', client_secret: 'test-client-secret' }),
+      tokens: () => {
+        return {
+          access_token: Buffer.from(this.#authToken).toString('base64'),
+          token_type: 'Bearer',
+        };
+      },
+      saveTokens: () => {},
+      redirectToAuthorization: () => {},
+      saveCodeVerifier: () => {},
+      codeVerifier: () => '',
+    };
+  }
+
+  #mergeRequestInit(requestInit?: RequestInit): RequestInit {
+    return {
+      ...requestInit,
+      headers: {
+        ...this.#normalizeHeaders(requestInit?.headers),
+        ...this.#headers,
+      },
+    };
+  }
+
+  #normalizeHeaders(headers?: HeadersInit): HeadersRecord {
+    if (!headers) return {};
+    if (Array.isArray(headers)) {
+      return Object.fromEntries(headers.map(([ key, value ]) => [ key, String(value) ]));
+    }
+    if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+      return Object.fromEntries(headers.entries());
+    }
+    return Object.fromEntries(Object.entries(headers).map(([ key, value ]) => [ key, String(value) ]));
+  }
+
+  get #url() {
+    const path = this.#path;
+    const method = this.#protocol === 'sse' ? 'get' : 'post';
+    return this.#app.httpRequest()[method](path).url;
+  }
+
+  get #path() {
+    const mcpConfig = MCPControllerRegister.instance?.mcpConfig;
+    if (mcpConfig) {
+      if (this.#protocol === 'sse') {
+        return mcpConfig.getSseInitPath(this.#serverName);
+      }
+      if (this.#protocol === 'stateless') {
+        return mcpConfig.getStatelessStreamPath(this.#serverName);
+      }
+      return mcpConfig.getStreamPath(this.#serverName);
+    }
+
+    const config = this.#app.config.mcp ?? {};
+    if (this.#serverName) {
+      const multipleServerConfig = config.multipleServer?.[this.#serverName] ?? {};
+      if (this.#protocol === 'sse') {
+        return multipleServerConfig.sseInitPath ?? `/mcp/${this.#serverName}/sse`;
+      }
+      if (this.#protocol === 'stateless') {
+        return multipleServerConfig.statelessStreamPath ?? `/mcp/${this.#serverName}/stateless/stream`;
+      }
+      return multipleServerConfig.streamPath ?? `/mcp/${this.#serverName}/stream`;
+    }
+
+    if (this.#protocol === 'sse') {
+      return config.sseInitPath ?? '/mcp/sse';
+    }
+    if (this.#protocol === 'stateless') {
+      return config.statelessStreamPath ?? '/mcp/stateless/stream';
+    }
+    return config.streamPath ?? '/mcp/stream';
+  }
+}

--- a/plugin/controller/test/mcp/mcpRequest.test.ts
+++ b/plugin/controller/test/mcp/mcpRequest.test.ts
@@ -7,7 +7,7 @@ const pluginRoot = process.cwd();
 const requireModule = createRequire(path.join(pluginRoot, 'package.json'));
 
 describe('plugin/controller/test/mcp/mcpRequest.test.ts', () => {
-  if (parseInt(process.version.slice(1, 3)) > 17) {
+  if (parseInt(process.versions.node.split('.')[0], 10) >= 18) {
     let app;
 
     before(async () => {

--- a/plugin/controller/test/mcp/mcpRequest.test.ts
+++ b/plugin/controller/test/mcp/mcpRequest.test.ts
@@ -1,0 +1,168 @@
+import mm from 'egg-mock';
+import path from 'node:path';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+const pluginRoot = process.cwd();
+const requireModule = createRequire(path.join(pluginRoot, 'package.json'));
+
+describe('plugin/controller/test/mcp/mcpRequest.test.ts', () => {
+  if (parseInt(process.version.slice(1, 3)) > 17) {
+    let app;
+
+    before(async () => {
+      mm(process.env, 'EGG_TYPESCRIPT', true);
+      mm(process, 'cwd', () => {
+        return pluginRoot;
+      });
+      app = mm.app({
+        baseDir: path.join(pluginRoot, 'test/fixtures/apps/mcp-app'),
+        framework: path.dirname(requireModule.resolve('egg')),
+      });
+      await app.ready();
+    });
+
+    after(async () => {
+      if (app) {
+        await app.close();
+      }
+      mm.restore();
+    });
+
+    it('should request default mcp server with app.mcpRequest()', async () => {
+      const mcp = app.mcpRequest();
+
+      const tools = await mcp.listTools();
+      assert.deepEqual(tools.tools.map(tool => tool.name), [
+        'start-notification-stream',
+        'bar',
+        'mockError',
+        'echoUser',
+        'traceTest',
+      ]);
+
+      const toolRes = await mcp.callTool('bar', {
+        name: 'aaa',
+      });
+      assert.deepEqual(toolRes, {
+        content: [{ type: 'text', text: 'npm package: aaa not found' }],
+      });
+
+      const userRes = await mcp.callTool('echoUser');
+      assert.deepEqual(userRes, {
+        content: [{ type: 'text', text: 'hello akita' }],
+      });
+
+      const traceRes = await mcp.callTool('traceTest');
+      assert.deepEqual(traceRes, {
+        content: [{ type: 'text', text: 'hello middleware' }],
+      });
+
+      const resources = await mcp.listResources();
+      assert.deepEqual(resources.resources.map(resource => resource.name), [ 'egg', 'mcp' ]);
+
+      const resourceRes = await mcp.readResource('mcp://npm/egg?version=4.10.0');
+      assert.deepEqual(resourceRes, {
+        contents: [{ uri: 'mcp://npm/egg?version=4.10.0', text: 'MOCK TEXT' }],
+      });
+
+      const prompts = await mcp.listPrompts();
+      assert.deepEqual(prompts.prompts.map(prompt => prompt.name), [ 'foo' ]);
+
+      const promptRes = await mcp.getPrompt('foo', {
+        name: 'bbb',
+      });
+      assert.deepEqual(promptRes, {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: 'Generate a concise but descriptive commit message for these changes:\n\nbbb',
+            },
+          },
+        ],
+      });
+
+      const client = await app.mcpRequest()
+        .set('custom-session-id', 'mcp-request-session')
+        .connect();
+      try {
+        assert.equal(client.protocol, 'streamable');
+        assert.equal(client.transport.sessionId, 'mcp-request-session');
+        assert.deepEqual((await client.listTools()).tools.map(tool => tool.name), [
+          'start-notification-stream',
+          'bar',
+          'mockError',
+          'echoUser',
+          'traceTest',
+        ]);
+      } finally {
+        await client.close();
+      }
+    });
+
+    it('should request named mcp server with app.mcpRequest(name)', async () => {
+      const mcp = app.mcpRequest('test').authToken('test-user');
+
+      const tools = await mcp.listTools();
+      assert.deepEqual(tools.tools.map(tool => tool.name), [
+        'test-start-notification-stream',
+        'testBar',
+        'testEchoUser',
+        'testTraceTest',
+      ]);
+
+      const toolRes = await mcp.callTool('testBar', {
+        name: 'aaa',
+      });
+      assert.deepEqual(toolRes, {
+        content: [{ type: 'text', text: 'npm package: aaa not found' }],
+      });
+
+      const userRes = await mcp.callTool('testEchoUser');
+      assert.deepEqual(userRes, {
+        content: [{ type: 'text', text: 'hello test-user' }],
+      });
+
+      const traceRes = await mcp.callTool('testTraceTest');
+      assert.deepEqual(traceRes, {
+        content: [{ type: 'text', text: 'hello middleware' }],
+      });
+
+      const resources = await mcp.listResources();
+      assert.deepEqual(resources.resources.map(resource => resource.name), [ 'testEgg', 'testMcp' ]);
+
+      const resourceRes = await mcp.readResource('mcp://npm/testEgg?version=4.10.0');
+      assert.deepEqual(resourceRes, {
+        contents: [{ uri: 'mcp://npm/testEgg?version=4.10.0', text: 'MOCK TEXT' }],
+      });
+
+      const prompts = await mcp.listPrompts();
+      assert.deepEqual(prompts.prompts.map(prompt => prompt.name), [ 'testFoo' ]);
+
+      const promptRes = await mcp.getPrompt('testFoo', {
+        name: 'bbb',
+      });
+      assert.deepEqual(promptRes, {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: 'Generate a concise but descriptive commit message for these changes:\n\nbbb',
+            },
+          },
+        ],
+      });
+
+      const statelessTools = await app.mcpRequest('test').stateless().listTools();
+      assert.deepEqual(statelessTools.tools.map(tool => tool.name), [
+        'test-start-notification-stream',
+        'testBar',
+        'testEchoUser',
+        'testTraceTest',
+      ]);
+    });
+  }
+});

--- a/plugin/controller/typings/index.d.ts
+++ b/plugin/controller/typings/index.d.ts
@@ -4,6 +4,7 @@ import '@eggjs/mcp-proxy';
 import { RootProtoManager } from '../lib/RootProtoManager';
 import { ControllerRegisterFactory } from '../lib/ControllerRegisterFactory';
 import { ControllerMetaBuilderFactory } from '@eggjs/tegg';
+import type MCPRequestUnitTest from '../lib/impl/mcp/MCPRequestUnitTest';
 
 declare module 'egg' {
   export interface TEggControllerApp extends MCPProxyApp {
@@ -13,5 +14,6 @@ declare module 'egg' {
   }
 
   export interface Application extends TEggControllerApp {
+    mcpRequest(name?: string): MCPRequestUnitTest;
   }
 }

--- a/plugin/mcp-proxy/app.ts
+++ b/plugin/mcp-proxy/app.ts
@@ -18,4 +18,10 @@ export default class AppHook {
       await (this.agent.mcpProxy as any)?.ready();
     }
   }
+
+  async beforeClose() {
+    if (this.agent.mcpProxy) {
+      await (this.agent.mcpProxy as any).close();
+    }
+  }
 }

--- a/plugin/mcp-proxy/index.ts
+++ b/plugin/mcp-proxy/index.ts
@@ -267,18 +267,22 @@ export class MCPProxyApiClient extends APIClientBase {
 
     const server = this.server;
     this.server = undefined;
-    if (server?.listening) {
-      await new Promise<void>((resolve, reject) => {
-        server.close(err => {
-          if (err) {
-            reject(err);
-            return;
-          }
-          resolve();
+    try {
+      if (server?.listening) {
+        await new Promise<void>((resolve, reject) => {
+          server.close(err => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            resolve();
+          });
+          server.closeAllConnections?.();
         });
-      });
+      }
+    } finally {
+      await super.close();
     }
-    await super.close();
   }
 
   setProxyHandler(type: MCPProtocols, handler: StreamableHTTPServerTransport['handleRequest'] | SSEServerTransport['handlePostMessage']) {

--- a/plugin/mcp-proxy/index.ts
+++ b/plugin/mcp-proxy/index.ts
@@ -227,6 +227,8 @@ export class MCPProxyApiClient extends APIClientBase {
   private port: number;
   private app: Application;
   private isAgent: boolean;
+  private server?: http.Server;
+  private _closed: boolean;
 
   constructor(options: {
     logger: EggLogger;
@@ -239,21 +241,44 @@ export class MCPProxyApiClient extends APIClientBase {
     this.port = 0;
     this.app = options.app;
     this.isAgent = !!options.isAgent;
+    this._closed = false;
   }
 
   async _init() {
     if (!this.isAgent) {
-      const server = http.createServer(async (req, res) => {
+      this.server = http.createServer(async (req, res) => {
         const type = req.headers['mcp-proxy-type'] as ProxyAction;
         await this.proxyHandlerMap[type]?.(req, res);
       });
       this.port = this.app.config.mcp?.proxyPort + (cluster.worker?.id ?? 0);
-      await new Promise(resolve => server.listen(this.port, () => {
+      await new Promise(resolve => this.server!.listen(this.port, () => {
         // const address = server.address()! as AddressInfo;
         // this.port = address.port;
         resolve(null);
       }));
     }
+  }
+
+  async close() {
+    if (this._closed) {
+      return;
+    }
+    this._closed = true;
+
+    const server = this.server;
+    this.server = undefined;
+    if (server?.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+    await super.close();
   }
 
   setProxyHandler(type: MCPProtocols, handler: StreamableHTTPServerTransport['handleRequest'] | SSEServerTransport['handlePostMessage']) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-level MCP test helper to create configurable MCP clients and interact with streamable, stateless, and SSE servers.

* **Tests**
  * New MCP test suite for tools, resources, prompts, and sessions (Node ≥18); improved test bootstrap and ensured client/fixture cleanup.

* **Bug Fixes**
  * Proxy and API client shutdown made graceful and idempotent.

* **Chores**
  * Test runner and type declarations updated for the new helper; test fixtures now expose and safely manage server instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->