### PR TITLE
fix: resolve MCP memory leaks

### DIFF
--- a/plugin/controller/lib/impl/mcp/MCPControllerRegister.ts
+++ b/plugin/controller/lib/impl/mcp/MCPControllerRegister.ts
@@ -552,6 +552,7 @@ export class MCPControllerRegister implements ControllerRegister {
     transport.onmessage = async (message: JSONRPCMessage, extra?: MessageExtraInfo) => {
       const args = [ message, extra ];
       // 这里需要 new 一个新的 ctx，否则 ContextProto 会未被初始化
+      // 创建一个 socket 并在请求结束后清理它，防止内存泄漏
       const socket = new Socket();
       const req = new IncomingMessage(socket);
       const res = new ServerResponse(req);
@@ -564,25 +565,46 @@ export class MCPControllerRegister implements ControllerRegister {
         'content-type': 'application/json',
       };
       const newCtx = self.app.createContext(req, res) as unknown as Context;
-      await ctx.app.ctxStorage.run(newCtx, async () => {
-        await mw(newCtx, async () => {
-          if (MCPControllerRegister.hooks.length > 0) {
-            for (const hook of MCPControllerRegister.hooks) {
-              await hook.preHandle?.(newCtx);
-            }
-          }
-          messageFunc!(message, extra);
-          if (isJSONRPCRequest(args[0])) {
-            const map = self.sseTransportsRequestMap.get(transport)!;
-            const wait = new Promise<null>((resolve, reject) => {
-              if (extra && 'id' in extra) {
-                map[extra.id as string] = { resolve, reject };
+      try {
+        await ctx.app.ctxStorage.run(newCtx, async () => {
+          await mw(newCtx, async () => {
+            if (MCPControllerRegister.hooks.length > 0) {
+              for (const hook of MCPControllerRegister.hooks) {
+                await hook.preHandle?.(newCtx);
               }
-            });
-            await wait;
-          }
+            }
+            messageFunc!(message, extra);
+            if (isJSONRPCRequest(args[0])) {
+              const map = self.sseTransportsRequestMap.get(transport)!;
+              if (extra && 'id' in extra) {
+                const requestId = extra.id as string;
+                const wait = new Promise<null>((resolve, reject) => {
+                  // 添加超时防止 promise 永远无法 resolve 导致内存泄漏
+                  const timeout = setTimeout(() => {
+                    delete map[requestId];
+                    resolve(null); // 超时时默认 resolve 避免 hang
+                  }, 30000); // 30秒超时
+                  map[requestId] = {
+                    resolve: val => {
+                      clearTimeout(timeout);
+                      resolve(val);
+                    },
+                    reject: err => {
+                      clearTimeout(timeout);
+                      reject(err);
+                    },
+                  };
+                });
+                await wait;
+              }
+            }
+          });
         });
-      });
+      } finally {
+        // 清理 Socket 和响应对象，防止内存泄漏
+        // 确保 socket 被销毁以释放文件描述符
+        socket.destroy();
+      }
     };
   }
 

--- a/standalone/service-worker/src/mcp/MCPControllerRegister.ts
+++ b/standalone/service-worker/src/mcp/MCPControllerRegister.ts
@@ -235,6 +235,9 @@ export class MCPControllerRegister implements ControllerRegister {
 
       const init = await resPromise;
 
+      // Clean up socket after request completes to prevent memory leaks
+      socket.destroy();
+
       ctx.response = new Response(Readable.toWeb(response.stream) as any, init) as any;
     };
 


### PR DESCRIPTION
- Add try-finally to clean up Socket, IncomingMessage, and ServerResponse objects after each SSE message to prevent file descriptor and memory leaks
- Add 30s timeout to promise resolution in sseTransportsRequestMap to prevent unresolved promises from hanging forever
- Apply same Socket cleanup fix to service-worker MCP controller

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential indefinite hang issue by implementing a bounded 30-second timeout for pending responses, improving system reliability and preventing resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->