### PR TITLE
feat(agent-runtime): expose per-message/tool/run timing via eggExt namespace

### DIFF
--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -100,7 +100,7 @@ export class AgentRuntime {
   // execution loops. Covers a TOCTOU window where another actor (most
   // notably cancelRun's commit-timeout watchdog, which writes Failed) sets
   // a terminal state while this worker has just exited the for-await loop
-  // but hasn't yet written rb.complete(usage). Completed is intentionally
+  // but hasn't yet written rb.complete(). Completed is intentionally
   // excluded so the normal success path is not routed through here.
   private static readonly POST_LOOP_TERMINAL_STATUSES = new Set<RunStatus>([
     RunStatus.Cancelling,
@@ -270,7 +270,7 @@ export class AgentRuntime {
       // Errors propagate so a failed persist routes through the catch.
       await flush(true);
 
-      await this.store.updateRun(run.id, rb.complete(usage));
+      await this.store.updateRun(run.id, rb.complete(usage, MessageConverter.extractApiDurationMs(streamMessages)));
 
       return rb.snapshot();
     } catch (err: unknown) {
@@ -367,7 +367,7 @@ export class AgentRuntime {
         // syncRun) so a normally-finished run always persists its transcript.
         await flush(true);
 
-        await this.store.updateRun(run.id, rb.complete(usage));
+        await this.store.updateRun(run.id, rb.complete(usage, MessageConverter.extractApiDurationMs(streamMessages)));
       } catch (err: unknown) {
         if (!abortController.signal.aborted) {
           // Non-abort failure (e.g. upstream stream terminated mid-turn).
@@ -551,7 +551,7 @@ export class AgentRuntime {
       // syncRun) so a normally-finished run always persists its transcript.
       const usage = MessageConverter.extractUsage(streamMessages);
       await flush(true);
-      await this.store.updateRun(runId, rb.complete(usage));
+      await this.store.updateRun(runId, rb.complete(usage, MessageConverter.extractApiDurationMs(streamMessages)));
 
       this.pushEvent(buffer, 'done', { result: 'success', runId });
     } catch (err: unknown) {

--- a/core/agent-runtime/src/AgentStoreUtils.ts
+++ b/core/agent-runtime/src/AgentStoreUtils.ts
@@ -4,6 +4,11 @@ export function nowUnix(): number {
   return Math.floor(Date.now() / 1000);
 }
 
+/** Current time as epoch milliseconds — for ms-granular run timing. */
+export function nowMs(): number {
+  return Date.now();
+}
+
 export function newMsgId(): string {
   return `msg_${crypto.randomUUID()}`;
 }

--- a/core/agent-runtime/src/MessageConverter.ts
+++ b/core/agent-runtime/src/MessageConverter.ts
@@ -36,6 +36,25 @@ export class MessageConverter {
   }
 
   /**
+   * Sum `duration_api_ms` across `result` messages — the run's pure model-API
+   * time in ms. Returns undefined when no result message carried it.
+   */
+  static extractApiDurationMs(messages: AgentMessage[]): number | undefined {
+    let total = 0;
+    let has = false;
+    for (const msg of messages) {
+      if (msg.type === 'result') {
+        const d = (msg as SDKResultMessage & { duration_api_ms?: number }).duration_api_ms;
+        if (typeof d === 'number') {
+          has = true;
+          total += d;
+        }
+      }
+    }
+    return has ? total : undefined;
+  }
+
+  /**
    * Filter out stream_event messages before persisting to thread storage.
    * Stream events are incremental deltas (one per token) only useful during
    * real-time streaming; the final assistant message already contains the

--- a/core/agent-runtime/src/OSSAgentStore.ts
+++ b/core/agent-runtime/src/OSSAgentStore.ts
@@ -316,7 +316,16 @@ export class OSSAgentStore implements AgentStore {
     const meta = JSON.parse(metaData) as ThreadMetadata;
     const nowMs = Date.now();
 
-    const lines = messages.map(m => JSON.stringify(m)).join('\n') + '\n';
+    // Stamp a server-side persisted-at (epoch ms) into each message's `eggExt`
+    // namespace — a fallback / drift-calibration clock that never overwrites the
+    // executor-stamped per-message `timing`. Shallow-copied so the caller's
+    // message objects are not mutated.
+    const stamped = messages.map(m => {
+      if (!m || typeof m !== 'object') return m;
+      const existing = (m as AgentMessage).eggExt;
+      return { ...m, eggExt: { ...(existing ?? {}), persistedAtMs: nowMs } } as AgentMessage;
+    });
+    const lines = stamped.map(m => JSON.stringify(m)).join('\n') + '\n';
     const messagesKey = this.threadMessagesKey(threadId);
 
     if (this.client.append) {

--- a/core/agent-runtime/src/RunBuilder.ts
+++ b/core/agent-runtime/src/RunBuilder.ts
@@ -1,7 +1,7 @@
 import type { RunObject, RunRecord, AgentRunConfig } from '@eggjs/tegg-types/agent-runtime';
 import { RunStatus, AgentErrorCode, AgentObjectType, InvalidRunStateTransitionError } from '@eggjs/tegg-types/agent-runtime';
 
-import { nowUnix } from './AgentStoreUtils';
+import { nowMs, nowUnix } from './AgentStoreUtils';
 
 /** Accumulated token usage — same shape as non-null RunRecord['usage']. */
 export type RunUsage = NonNullable<RunRecord['usage']>;
@@ -26,6 +26,11 @@ export class RunBuilder {
   private completedAt?: number;
   private cancelledAt?: number;
   private failedAt?: number;
+  // ms-granular timing: absolute epoch-ms points (startedAtMs/completedAtMs) and durations (durationMs/apiDurationMs).
+  private startedAtMs?: number;
+  private completedAtMs?: number;
+  private durationMs?: number | null;
+  private apiDurationMs?: number | null;
   private lastError?: { code: string; message: string } | null;
   private usage?: RunUsage;
 
@@ -57,6 +62,10 @@ export class RunBuilder {
     rb.completedAt = run.completedAt ?? undefined;
     rb.cancelledAt = run.cancelledAt ?? undefined;
     rb.failedAt = run.failedAt ?? undefined;
+    rb.startedAtMs = run.startedAtMs ?? undefined;
+    rb.completedAtMs = run.completedAtMs ?? undefined;
+    rb.durationMs = run.durationMs ?? undefined;
+    rb.apiDurationMs = run.apiDurationMs ?? undefined;
     rb.lastError = run.lastError ?? undefined;
     if (run.usage) {
       rb.usage = { ...run.usage };
@@ -70,22 +79,38 @@ export class RunBuilder {
       throw new InvalidRunStateTransitionError(this.status, RunStatus.InProgress);
     }
     this.status = RunStatus.InProgress;
-    this.startedAt = nowUnix();
-    return { status: this.status, startedAt: this.startedAt };
+    // Derive the seconds field from the same ms reading so the two never disagree across a second boundary.
+    this.startedAtMs = nowMs();
+    this.startedAt = Math.floor(this.startedAtMs / 1000);
+    return { status: this.status, startedAt: this.startedAt, startedAtMs: this.startedAtMs };
   }
 
-  /** in_progress -> completed. Returns store update. */
-  complete(usage?: RunUsage): Partial<RunRecord> {
+  /**
+   * in_progress -> completed. Returns store update.
+   *
+   * `apiDurationMs` is the run's summed pure-model-API time (from result
+   * messages' `duration_api_ms`); pass undefined when no result carried it.
+   * `durationMs` is derived as `completedAtMs - startedAtMs` (null if the run
+   * was restored without a startedAtMs).
+   */
+  complete(usage?: RunUsage, apiDurationMs?: number): Partial<RunRecord> {
     if (this.status !== RunStatus.InProgress) {
       throw new InvalidRunStateTransitionError(this.status, RunStatus.Completed);
     }
     this.status = RunStatus.Completed;
-    this.completedAt = nowUnix();
+    // Derive the seconds field from the same ms reading so the two never disagree across a second boundary.
+    this.completedAtMs = nowMs();
+    this.completedAt = Math.floor(this.completedAtMs / 1000);
+    this.durationMs = this.startedAtMs != null ? this.completedAtMs - this.startedAtMs : null;
+    this.apiDurationMs = apiDurationMs ?? null;
     this.usage = usage;
     return {
       status: this.status,
       usage,
       completedAt: this.completedAt,
+      completedAtMs: this.completedAtMs,
+      durationMs: this.durationMs,
+      apiDurationMs: this.apiDurationMs,
     };
   }
 
@@ -152,6 +177,10 @@ export class RunBuilder {
       completedAt: this.completedAt ?? null,
       cancelledAt: this.cancelledAt ?? null,
       failedAt: this.failedAt ?? null,
+      startedAtMs: this.startedAtMs ?? null,
+      completedAtMs: this.completedAtMs ?? null,
+      durationMs: this.durationMs ?? null,
+      apiDurationMs: this.apiDurationMs ?? null,
       usage: this.usage ?? null,
       metadata: this.metadata,
       config: this.config,

--- a/core/agent-runtime/test/MessageConverter.test.ts
+++ b/core/agent-runtime/test/MessageConverter.test.ts
@@ -100,6 +100,39 @@ describe('test/MessageConverter.test.ts', () => {
     });
   });
 
+  describe('extractApiDurationMs', () => {
+    it('should return undefined when no result messages', () => {
+      assert.equal(MessageConverter.extractApiDurationMs([
+        { type: 'assistant', message: { role: 'assistant', content: [] } },
+      ]), undefined);
+    });
+
+    it('should return undefined when result has no duration_api_ms', () => {
+      assert.equal(MessageConverter.extractApiDurationMs([
+        { type: 'result', subtype: 'success' } as SDKResultMessage,
+      ]), undefined);
+    });
+
+    it('should extract duration_api_ms from a single result', () => {
+      assert.equal(MessageConverter.extractApiDurationMs([
+        { type: 'result', subtype: 'success', duration_api_ms: 5200 } as unknown as SDKResultMessage,
+      ]), 5200);
+    });
+
+    it('should accumulate duration_api_ms across multiple results', () => {
+      assert.equal(MessageConverter.extractApiDurationMs([
+        { type: 'result', subtype: 'success', duration_api_ms: 5200 } as unknown as SDKResultMessage,
+        { type: 'result', subtype: 'success', duration_api_ms: 800 } as unknown as SDKResultMessage,
+      ]), 6000);
+    });
+
+    it('should ignore non-numeric duration_api_ms', () => {
+      assert.equal(MessageConverter.extractApiDurationMs([
+        { type: 'result', subtype: 'success', duration_api_ms: 'x' } as unknown as SDKResultMessage,
+      ]), undefined);
+    });
+  });
+
   describe('filterForStorage', () => {
     it('should filter out stream_event messages', () => {
       const messages: AgentMessage[] = [

--- a/core/agent-runtime/test/OSSAgentStore.test.ts
+++ b/core/agent-runtime/test/OSSAgentStore.test.ts
@@ -76,6 +76,46 @@ describe('test/OSSAgentStore.test.ts', () => {
       assert.equal(fetched.messages[1].type, 'assistant');
     });
 
+    it('should stamp eggExt.persistedAtMs on every persisted message', async () => {
+      const thread = await store.createThread();
+      const before = Date.now();
+      await store.appendMessages(thread.id, [
+        { type: 'user', message: { role: 'user', content: 'hi' } },
+      ]);
+      const msg = (await store.getThread(thread.id)).messages[0] as AgentMessage & {
+        eggExt?: { persistedAtMs?: number };
+      };
+      assert.equal(typeof msg.eggExt?.persistedAtMs, 'number');
+      assert.ok(msg.eggExt!.persistedAtMs! >= before);
+    });
+
+    it('should not overwrite executor-stamped eggExt.timing', async () => {
+      const thread = await store.createThread();
+      await store.appendMessages(thread.id, [
+        {
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+          eggExt: { runId: 'run_1', timing: { receivedAtMs: 111, genMs: 22 } },
+        } as AgentMessage,
+      ]);
+      const msg = (await store.getThread(thread.id)).messages[0] as AgentMessage & {
+        eggExt?: { runId?: string; persistedAtMs?: number; timing?: { receivedAtMs?: number; genMs?: number } };
+      };
+      assert.equal(msg.eggExt?.runId, 'run_1');
+      assert.equal(msg.eggExt?.timing?.receivedAtMs, 111);
+      assert.equal(msg.eggExt?.timing?.genMs, 22);
+      assert.equal(typeof msg.eggExt?.persistedAtMs, 'number');
+    });
+
+    it('should not mutate the caller-provided message objects', async () => {
+      const thread = await store.createThread();
+      const original = { type: 'user', message: { role: 'user', content: 'hi' } } as AgentMessage & {
+        eggExt?: unknown;
+      };
+      await store.appendMessages(thread.id, [ original ]);
+      assert.equal(original.eggExt, undefined); // caller object untouched
+    });
+
     it('should append messages incrementally', async () => {
       const thread = await store.createThread();
       await store.appendMessages(thread.id, [

--- a/core/agent-runtime/test/RunBuilder.test.ts
+++ b/core/agent-runtime/test/RunBuilder.test.ts
@@ -218,6 +218,58 @@ describe('test/RunBuilder.test.ts', () => {
     });
   });
 
+  describe('ms-granular timing', () => {
+    it('start should set startedAtMs as epoch ms', () => {
+      const rb = RunBuilder.create(makeRunRecord(), 'thread_1');
+      const update = rb.start();
+      assert.equal(typeof update.startedAtMs, 'number');
+      assert.ok(update.startedAtMs! >= 1_000_000_000_000); // epoch ms, not seconds
+      assert.equal(typeof rb.snapshot().startedAtMs, 'number');
+    });
+
+    it('complete should set completedAtMs, durationMs and apiDurationMs', () => {
+      const rb = RunBuilder.create(makeRunRecord(), 'thread_1');
+      rb.start();
+      const update = rb.complete({ promptTokens: 1, completionTokens: 2, totalTokens: 3 }, 4200);
+      assert.equal(typeof update.completedAtMs, 'number');
+      assert.equal(typeof update.durationMs, 'number');
+      assert.ok(update.durationMs! >= 0);
+      assert.equal(update.apiDurationMs, 4200);
+      const snap = rb.snapshot();
+      assert.equal(snap.apiDurationMs, 4200);
+      assert.equal(typeof snap.durationMs, 'number');
+    });
+
+    it('complete should null durationMs/apiDurationMs when restored without startedAtMs and no api time', () => {
+      const rb = RunBuilder.create(makeRunRecord({ status: RunStatus.InProgress }), 'thread_1');
+      const update = rb.complete();
+      assert.equal(update.durationMs, null);
+      assert.equal(update.apiDurationMs, null);
+    });
+
+    it('create should restore ms timing fields into snapshot', () => {
+      const snap = RunBuilder.create(makeRunRecord({
+        status: RunStatus.Completed,
+        startedAtMs: 1_700_000_000_000,
+        completedAtMs: 1_700_000_005_000,
+        durationMs: 5000,
+        apiDurationMs: 4200,
+      }), 'thread_1').snapshot();
+      assert.equal(snap.startedAtMs, 1_700_000_000_000);
+      assert.equal(snap.completedAtMs, 1_700_000_005_000);
+      assert.equal(snap.durationMs, 5000);
+      assert.equal(snap.apiDurationMs, 4200);
+    });
+
+    it('snapshot defaults ms timing to null', () => {
+      const snap = RunBuilder.create(makeRunRecord(), 'thread_1').snapshot();
+      assert.equal(snap.startedAtMs, null);
+      assert.equal(snap.completedAtMs, null);
+      assert.equal(snap.durationMs, null);
+      assert.equal(snap.apiDurationMs, null);
+    });
+  });
+
   describe('full lifecycle', () => {
     it('should support queued → in_progress → completed', () => {
       const rb = RunBuilder.create(makeRunRecord(), 'thread_1');

--- a/core/types/agent-runtime/AgentMessage.ts
+++ b/core/types/agent-runtime/AgentMessage.ts
@@ -38,38 +38,94 @@ export interface InputMessage {
   metadata?: Record<string, unknown>;
 }
 
+// ===== Framework extension envelope (eggExt) =====
+// Additive metadata the agent-runtime / executor layer attaches to messages,
+// namespaced under a single `eggExt` key so it never collides with current or
+// future Claude Agent SDK fields. SDK payloads (the `message` field) are never
+// touched. Time-field naming convention: absolute epoch-ms points end in
+// `AtMs`; durations / intervals in ms end in `Ms`.
+
+/** Per-message timing, stamped by the executor as each message streams in. */
+export interface MessageTiming {
+  /** Epoch ms when the executor received this message — authoritative per-message time. */
+  receivedAtMs: number;
+  /** Gap in ms since the previous persisted message's `receivedAtMs`. */
+  sincePrevMs?: number;
+  /** assistant only: ms the model took to generate this message (turn `message_start` → arrival). */
+  genMs?: number;
+  /** assistant only: time-to-first-token in ms, carried over from the turn's `stream_event`. */
+  ttftMs?: number;
+}
+
+/** Precise execution timing for a single tool call, derived from PreToolUse / PostToolUse hooks. */
+export interface ToolTiming {
+  toolUseId: string;
+  name: string;
+  /** Epoch ms when the tool started executing (PreToolUse). */
+  startedAtMs: number;
+  /** Epoch ms when the tool finished (PostToolUse); `null` when interrupted before completion. */
+  endedAtMs: number | null;
+  /** `endedAtMs - startedAtMs`; `null` when the tool did not finish. */
+  durationMs: number | null;
+  isError?: boolean;
+  /** Set when the tool ran inside a sub-agent. */
+  agentId?: string;
+}
+
+/** Single `eggExt` namespace carrying all framework extension fields on a message. */
+export interface EggExt {
+  /** Owning runId. Mirrored here as the forward-looking canonical location; also kept top-level for back-compat. */
+  runId?: string;
+  /** Per-message timing. */
+  timing?: MessageTiming;
+  /** Per-tool timing; present on `user` messages that carry tool_result blocks. */
+  toolTimings?: ToolTiming[];
+  /**
+   * Epoch ms when the store persisted this message (server-side clock). A
+   * fallback / drift-calibration timestamp stamped on every persisted message;
+   * it never overwrites the executor-stamped per-message `timing`. For input
+   * messages (which carry no `timing`) this is their only time field.
+   */
+  persistedAtMs?: number;
+}
+
+/** Mixin giving every AgentMessage member the `eggExt` extension namespace. */
+export interface AgentMessageExtensions {
+  eggExt?: EggExt;
+}
+
 // ===== AgentMessage — aligned with Claude Agent SDK SDKMessage =====
 // Lightweight subset of SDK message types. The framework only needs to
 // discriminate on `type` for a handful of core message kinds; everything
 // else passes through as SDKGenericMessage.
 
-export interface SDKSystemMessage {
+export interface SDKSystemMessage extends AgentMessageExtensions {
   type: 'system';
   subtype: string;
   session_id?: string;
   [key: string]: unknown;
 }
 
-export interface SDKStreamEvent {
+export interface SDKStreamEvent extends AgentMessageExtensions {
   type: 'stream_event';
   event: unknown;
   session_id?: string;
   [key: string]: unknown;
 }
 
-export interface SDKUserMessage {
+export interface SDKUserMessage extends AgentMessageExtensions {
   type: 'user';
   message: unknown;
   [key: string]: unknown;
 }
 
-export interface SDKAssistantMessage {
+export interface SDKAssistantMessage extends AgentMessageExtensions {
   type: 'assistant';
   message: unknown;
   [key: string]: unknown;
 }
 
-export interface SDKResultMessage {
+export interface SDKResultMessage extends AgentMessageExtensions {
   type: 'result';
   subtype: string;
   usage?: {
@@ -82,7 +138,7 @@ export interface SDKResultMessage {
   [key: string]: unknown;
 }
 
-export interface SDKGenericMessage {
+export interface SDKGenericMessage extends AgentMessageExtensions {
   type: string;
   [key: string]: unknown;
 }

--- a/core/types/agent-runtime/AgentRuntime.ts
+++ b/core/types/agent-runtime/AgentRuntime.ts
@@ -30,10 +30,17 @@ export interface RunObject {
   threadId: string;
   status: RunStatus;
   lastError?: { code: string; message: string } | null;
-  startedAt?: number | null;
-  completedAt?: number | null;
-  cancelledAt?: number | null;
-  failedAt?: number | null;
+  startedAt?: number | null; // Unix seconds (legacy; retained for back-compat)
+  completedAt?: number | null; // Unix seconds
+  cancelledAt?: number | null; // Unix seconds
+  failedAt?: number | null; // Unix seconds
+  // ms-granular timing (new). Naming: absolute epoch-ms points end in `AtMs`, durations in `Ms`.
+  startedAtMs?: number | null;
+  completedAtMs?: number | null;
+  /** completedAtMs - startedAtMs (end-to-end run wall time in ms). */
+  durationMs?: number | null;
+  /** Sum of result.duration_api_ms across the run (pure model API time in ms). */
+  apiDurationMs?: number | null;
   usage?: { promptTokens: number; completionTokens: number; totalTokens: number } | null;
   metadata?: Record<string, unknown>;
   config?: AgentRunConfig;

--- a/core/types/agent-runtime/AgentStore.ts
+++ b/core/types/agent-runtime/AgentStore.ts
@@ -63,11 +63,18 @@ export interface RunRecord {
   usage?: { promptTokens: number; completionTokens: number; totalTokens: number } | null;
   config?: AgentRunConfig;
   metadata?: Record<string, unknown>;
-  createdAt: number;
-  startedAt?: number | null;
-  completedAt?: number | null;
-  cancelledAt?: number | null;
-  failedAt?: number | null;
+  createdAt: number; // Unix seconds
+  startedAt?: number | null; // Unix seconds (legacy; retained for back-compat)
+  completedAt?: number | null; // Unix seconds
+  cancelledAt?: number | null; // Unix seconds
+  failedAt?: number | null; // Unix seconds
+  // ms-granular timing (new). Naming: absolute epoch-ms points end in `AtMs`, durations in `Ms`.
+  startedAtMs?: number | null;
+  completedAtMs?: number | null;
+  /** completedAtMs - startedAtMs (end-to-end run wall time in ms). */
+  durationMs?: number | null;
+  /** Sum of result.duration_api_ms across the run (pure model API time in ms). */
+  apiDurationMs?: number | null;
 }
 
 // ===== Store interface =====


### PR DESCRIPTION
## Why
Session data lacks timing: per-message latency, per-tool start/end/duration, and ms-granular run timing. The Claude Agent SDK only reports a whole-conversation total on the `result` message — individual assistant/user/tool_use messages carry no time at all. This PR adds the storage/contract-layer fields to carry that timing (the actual stamping happens executor-side).

## What
All framework extension fields live under a single top-level `eggExt` namespace so they never collide with Claude Agent SDK message fields (the SDK `message` payload is untouched). Time-field naming: absolute epoch-ms points end in `AtMs`, durations/intervals in `Ms`; existing seconds-level run fields are kept for back-compat.

- **types**: `MessageTiming` / `ToolTiming` / `EggExt`; every `AgentMessage` member carries an optional `eggExt`. `RunRecord`/`RunObject` gain ms timing (`startedAtMs`/`completedAtMs`/`durationMs`/`apiDurationMs`).
- **RunBuilder**: records ms timing and derives `durationMs` (null when restored without `startedAtMs`); seconds fields are derived from the same ms reading to avoid cross-second drift.
- **MessageConverter.extractApiDurationMs**: sums `result.duration_api_ms`.
- **OSSAgentStore.appendMessages**: stamps a server-side `eggExt.persistedAtMs` on each persisted message (shallow-copied; never overwrites executor-stamped `timing`).

## Compatibility
All new fields are optional; seconds-level run fields unchanged; old consumers ignore `eggExt`. `getThread` still returns only user/assistant by default, and the `eggExt` (timing/toolTimings) on those is visible alongside them.

## Test
New coverage for ms timing, `extractApiDurationMs`, and `persistedAtMs` stamping; full agent-runtime suite green (200 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added millisecond-precision run lifecycle metrics (started/completed, total duration) plus `apiDurationMs`, now captured and exposed in run snapshots.
  * Persisted messages are now stamped with `persistedAtMs` at append time (without mutating the original inputs). Message shapes now support optional timing metadata.

* **Tests**
  * Added unit coverage for `apiDurationMs` extraction, message stamping (including no input mutation), and RunBuilder millisecond timing restoration/snapshotting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->