### PR TITLE
feat: support context decorator in MCP controllers

### DIFF
--- a/core/controller-decorator/src/impl/mcp/MCPControllerPromptMetaBuilder.ts
+++ b/core/controller-decorator/src/impl/mcp/MCPControllerPromptMetaBuilder.ts
@@ -25,10 +25,12 @@ export class MCPControllerPromptMetaBuilder {
     const params = MCPInfoUtil.getMCPPromptParams(this.clazz, this.methodName);
     const detail = MCPInfoUtil.getMCPPromptArgsIndex(this.clazz, this.methodName);
     const extra = MCPInfoUtil.getMCPExtra(this.clazz, this.methodName);
+    const contextParamIndex = MethodInfoUtil.getMethodContextIndex(this.clazz, this.methodName);
 
     return new MCPPromptMeta({
       name: this.methodName,
       middlewares,
+      contextParamIndex,
       needAcl,
       aclCode,
       detail,

--- a/core/controller-decorator/src/impl/mcp/MCPControllerResourceMetaBuilder.ts
+++ b/core/controller-decorator/src/impl/mcp/MCPControllerResourceMetaBuilder.ts
@@ -24,10 +24,12 @@ export class MCPControllerResourceMetaBuilder {
     const aclCode = MethodInfoUtil.getMethodAcl(this.clazz, this.methodName);
     const params = MCPInfoUtil.getMCPResourceParams(this.clazz, this.methodName);
     const extra = MCPInfoUtil.getMCPExtra(this.clazz, this.methodName);
+    const contextParamIndex = MethodInfoUtil.getMethodContextIndex(this.clazz, this.methodName);
 
     return new MCPResourceMeta({
       name: this.methodName,
       middlewares,
+      contextParamIndex,
       needAcl,
       aclCode,
       extra,

--- a/core/controller-decorator/src/impl/mcp/MCPControllerToolMetaBuilder.ts
+++ b/core/controller-decorator/src/impl/mcp/MCPControllerToolMetaBuilder.ts
@@ -25,10 +25,12 @@ export class MCPControllerToolMetaBuilder {
     const params = MCPInfoUtil.getMCPToolParams(this.clazz, this.methodName);
     const detail = MCPInfoUtil.getMCPToolArgsIndex(this.clazz, this.methodName);
     const extra = MCPInfoUtil.getMCPExtra(this.clazz, this.methodName);
+    const contextParamIndex = MethodInfoUtil.getMethodContextIndex(this.clazz, this.methodName);
 
     return new MCPToolMeta({
       name: this.methodName,
       middlewares,
+      contextParamIndex,
       needAcl,
       aclCode,
       detail,

--- a/core/controller-decorator/src/model/MCPPromptMeta.ts
+++ b/core/controller-decorator/src/model/MCPPromptMeta.ts
@@ -1,7 +1,7 @@
-import type { MiddlewareFunc } from '@eggjs/tegg-types';
+import type { MethodMeta, MiddlewareFunc } from '@eggjs/tegg-types';
 import { PromptArgsSchemaDetail } from '../../src/util/MCPInfoUtil';
 
-export class MCPPromptMeta {
+export class MCPPromptMeta implements MethodMeta {
   readonly name: string;
   readonly needAcl: boolean;
   readonly mcpName?: string;
@@ -11,10 +11,12 @@ export class MCPPromptMeta {
   readonly middlewares: readonly MiddlewareFunc[];
   readonly extra?: number;
   readonly title?: string;
+  readonly contextParamIndex: number | undefined;
 
   constructor(opt: {
     name: string;
     middlewares: MiddlewareFunc[];
+    contextParamIndex?: number;
     needAcl?: boolean;
     aclCode?: string,
     description?: string;
@@ -32,5 +34,6 @@ export class MCPPromptMeta {
     this.detail = opt.detail;
     this.extra = opt.extra;
     this.title = opt.title;
+    this.contextParamIndex = opt.contextParamIndex;
   }
 }

--- a/core/controller-decorator/src/model/MCPResourceMeta.ts
+++ b/core/controller-decorator/src/model/MCPResourceMeta.ts
@@ -1,8 +1,8 @@
-import type { MiddlewareFunc } from '@eggjs/tegg-types';
+import type { MethodMeta, MiddlewareFunc } from '@eggjs/tegg-types';
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ResourceMetadata } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-export class MCPResourceMeta {
+export class MCPResourceMeta implements MethodMeta {
   readonly name: string;
   readonly needAcl: boolean;
   readonly aclCode?: string;
@@ -12,10 +12,12 @@ export class MCPResourceMeta {
   readonly metadata?: ResourceMetadata;
   readonly middlewares: readonly MiddlewareFunc[];
   readonly extra?: number;
+  readonly contextParamIndex: number | undefined;
 
   constructor(opt: {
     name: string;
     middlewares: MiddlewareFunc[];
+    contextParamIndex?: number;
     needAcl?: boolean;
     aclCode?: string,
     mcpName?: string;
@@ -35,5 +37,6 @@ export class MCPResourceMeta {
     this.aclCode = opt.aclCode;
     this.mcpName = opt.mcpName;
     this.extra = opt.extra;
+    this.contextParamIndex = opt.contextParamIndex;
   }
 }

--- a/core/controller-decorator/src/model/MCPToolMeta.ts
+++ b/core/controller-decorator/src/model/MCPToolMeta.ts
@@ -1,8 +1,8 @@
-import type { MiddlewareFunc } from '@eggjs/tegg-types';
+import type { MethodMeta, MiddlewareFunc } from '@eggjs/tegg-types';
 import { ToolArgsSchemaDetail } from '../../src/util/MCPInfoUtil';
 
 
-export class MCPToolMeta {
+export class MCPToolMeta implements MethodMeta {
   readonly name: string;
   readonly needAcl: boolean;
   readonly aclCode?: string;
@@ -11,10 +11,12 @@ export class MCPToolMeta {
   readonly detail?: ToolArgsSchemaDetail;
   readonly middlewares: readonly MiddlewareFunc[];
   readonly extra?: number;
+  readonly contextParamIndex: number | undefined;
 
   constructor(opt: {
     name: string;
     middlewares: MiddlewareFunc[];
+    contextParamIndex?: number;
     needAcl?: boolean;
     aclCode?: string,
     description?: string;
@@ -30,5 +32,6 @@ export class MCPToolMeta {
     this.aclCode = opt.aclCode;
     this.detail = opt.detail;
     this.extra = opt.extra;
+    this.contextParamIndex = opt.contextParamIndex;
   }
 }

--- a/core/controller-decorator/test/MCPMeta.test.ts
+++ b/core/controller-decorator/test/MCPMeta.test.ts
@@ -19,8 +19,11 @@ describe('test/MCPMeta.test.ts', () => {
     assert(fooControllerMetaData.tools[0].name === 'bar');
     assert(fooControllerMetaData.resources[0].name === 'car');
     assert(fooControllerMetaData.resources[0].template instanceof ResourceTemplate);
-    assert(fooControllerMetaData.tools[0].detail?.argsSchema === ToolType);
-    assert(fooControllerMetaData.prompts[0].detail?.argsSchema === PromptType);
+    assert.strictEqual(fooControllerMetaData.tools[0].detail?.argsSchema as unknown, ToolType);
+    assert.strictEqual(fooControllerMetaData.prompts[0].detail?.argsSchema as unknown, PromptType);
+    assert(fooControllerMetaData.prompts[0].contextParamIndex === 0);
+    assert(fooControllerMetaData.tools[0].contextParamIndex === 1);
+    assert(fooControllerMetaData.resources[0].contextParamIndex === 1);
     assert(fooControllerMetaData.timeout === 60000);
   });
 });

--- a/core/controller-decorator/test/fixtures/MCPController.ts
+++ b/core/controller-decorator/test/fixtures/MCPController.ts
@@ -5,6 +5,7 @@ import { MCPController } from "../../src/decorator/mcp/MCPController";
 import * as z from 'zod/v4';
 import { MCPResource } from "../../src/decorator/mcp/MCPResource";
 import { Extra } from "../../src/decorator/mcp/Extra";
+import { Context } from "../../src/decorator/Context";
 
 export const PromptType = {
   name: z.string(),
@@ -20,7 +21,8 @@ export const ToolType = {
 })
 export class MCPFooController {
   @MCPPrompt()
-  async foo(@PromptArgsSchema(PromptType) args: PromptArgs<typeof PromptType>): Promise<MCPPromptResponse> {
+  async foo(@Context() ctx: object, @PromptArgsSchema(PromptType as any) args: PromptArgs<any>): Promise<MCPPromptResponse> {
+    void ctx;
     return {
       messages: [
         {
@@ -35,7 +37,8 @@ export class MCPFooController {
   }
 
   @MCPTool()
-  async bar(@ToolArgsSchema(ToolType) args: ToolArgs<typeof ToolType>): Promise<MCPToolResponse> {
+  async bar(@ToolArgsSchema(ToolType as any) args: ToolArgs<any>, @Context() ctx: object): Promise<MCPToolResponse> {
+    void ctx;
     return {
       content: [
         {
@@ -55,7 +58,8 @@ export class MCPFooController {
       },
     ],
   })
-  async car(uri: URL, @Extra() extra): Promise<MCPResourceResponse> {
+  async car(uri: URL, @Context() ctx: object, @Extra() extra): Promise<MCPResourceResponse> {
+    void ctx;
     console.log(extra);
     return {
       contents: [{
@@ -65,4 +69,3 @@ export class MCPFooController {
     };
   }
 }
-

--- a/plugin/controller/lib/impl/mcp/MCPControllerRegister.ts
+++ b/plugin/controller/lib/impl/mcp/MCPControllerRegister.ts
@@ -788,6 +788,7 @@ export class MCPControllerRegister implements ControllerRegister {
               `chair-mcp-${metadata.name ?? this.app.name}-server`,
             version: this.controllerMeta.version ?? '1.0.0',
             hooks: MCPControllerRegister.hooks,
+            getContext: () => this.app.currentContext,
           });
         };
         this.mcpStatelessStreamServerInit(metadata.name);

--- a/plugin/controller/lib/impl/mcp/MCPServerHelper.ts
+++ b/plugin/controller/lib/impl/mcp/MCPServerHelper.ts
@@ -15,11 +15,14 @@ export interface MCPServerHelperOptions {
   name: string;
   version: string;
   hooks: MCPControllerHook[];
+  getContext?: () => unknown;
 }
 
 export class MCPServerHelper {
   server: McpServer;
   hooks: MCPControllerHook[];
+  private readonly getContext?: () => unknown;
+
   constructor(opts: MCPServerHelperOptions) {
     this.server = new McpServer(
       {
@@ -29,6 +32,46 @@ export class MCPServerHelper {
       { capabilities: { logging: {} } },
     );
     this.hooks = opts.hooks;
+    this.getContext = opts.getContext;
+  }
+
+  private buildResourceArgs(args: any[], resourceMeta: MCPResourceMeta) {
+    const newArgs = [ ...args ];
+    if (resourceMeta.extra !== undefined) {
+      newArgs[resourceMeta.extra] = resourceMeta.template ? args[2] : args[1];
+    }
+    if (resourceMeta.contextParamIndex !== undefined) {
+      newArgs[resourceMeta.contextParamIndex] = this.getContext?.();
+    }
+    return newArgs;
+  }
+
+  private buildToolArgs(args: any[], toolMeta: MCPToolMeta, hasSchema: boolean) {
+    const newArgs = [ ...args ];
+    if (hasSchema && toolMeta.detail) {
+      newArgs[toolMeta.detail.index] = args[0];
+    }
+    if (toolMeta.extra !== undefined) {
+      newArgs[toolMeta.extra] = hasSchema ? args[1] : args[0];
+    }
+    if (toolMeta.contextParamIndex !== undefined) {
+      newArgs[toolMeta.contextParamIndex] = this.getContext?.();
+    }
+    return newArgs;
+  }
+
+  private buildPromptArgs(args: any[], promptMeta: MCPPromptMeta, hasSchema: boolean) {
+    const newArgs = [ ...args ];
+    if (hasSchema && promptMeta.detail) {
+      newArgs[promptMeta.detail.index] = args[0];
+    }
+    if (promptMeta.extra !== undefined) {
+      newArgs[promptMeta.extra] = hasSchema ? args[1] : args[0];
+    }
+    if (promptMeta.contextParamIndex !== undefined) {
+      newArgs[promptMeta.contextParamIndex] = this.getContext?.();
+    }
+    return newArgs;
   }
 
   async mcpResourceRegister(
@@ -43,10 +86,11 @@ export class MCPServerHelper {
       );
       const realObj = eggObj.obj;
       const realMethod = realObj[resourceMeta.name];
+      const newArgs = this.buildResourceArgs(args, resourceMeta);
       return Reflect.apply(
         realMethod,
         realObj,
-        args,
+        newArgs,
       ) as ReturnType<ReadResourceCallback>;
     };
     const name = resourceMeta.mcpName ?? resourceMeta.name;
@@ -87,20 +131,7 @@ export class MCPServerHelper {
       );
       const realObj = eggObj.obj;
       const realMethod = realObj[toolMeta.name];
-      let newArgs: any[] = [];
-      if (schema && toolMeta.detail) {
-        // 如果有 schema 则证明入参第一个就是 schema
-        newArgs[toolMeta.detail.index] = args[0];
-
-        // 如果有 schema 则证明入参第二个就是 extra
-        if (toolMeta.extra) {
-          newArgs[toolMeta.extra] = args[1];
-        }
-      } else if (toolMeta.extra) {
-        // 无 schema, 那么入参第一个就是 extra
-        newArgs[toolMeta.extra] = args[0];
-      }
-      newArgs = [ ...newArgs, ...args ];
+      const newArgs = this.buildToolArgs(args, toolMeta, !!schema);
       return Reflect.apply(realMethod, realObj, newArgs) as ReturnType<ToolCallback>;
     };
     this.server.registerTool(name, {
@@ -133,20 +164,7 @@ export class MCPServerHelper {
       const eggObj = await getOrCreateEggObject(controllerProto, controllerProto.name);
       const realObj = eggObj.obj;
       const realMethod = realObj[promptMeta.name];
-      let newArgs: any[] = [];
-      if (schema && promptMeta.detail) {
-        // 如果有 schema 则证明入参第一个就是 schema
-        newArgs[promptMeta.detail.index] = args[0];
-
-        // 如果有 schema 则证明入参第二个就是 extra
-        if (promptMeta.extra) {
-          newArgs[promptMeta.extra] = args[1];
-        }
-      } else if (promptMeta.extra) {
-        // 无 schema, 那么入参第一个就是 extra
-        newArgs[promptMeta.extra] = args[0];
-      }
-      newArgs = [ ...newArgs, ...args ];
+      const newArgs = this.buildPromptArgs(args, promptMeta, !!schema);
       return Reflect.apply(realMethod, realObj, newArgs) as ReturnType<PromptCallback>;
     };
     this.server.registerPrompt(name, {

--- a/plugin/controller/test/fixtures/apps/mcp-app/app/controller/McpController.ts
+++ b/plugin/controller/test/fixtures/apps/mcp-app/app/controller/McpController.ts
@@ -15,7 +15,9 @@ import {
   ToolArgsSchema,
   Extra,
   ToolExtra,
+  Context,
 } from '@eggjs/tegg';
+import type { Context as EggContext } from 'egg';
 import * as z from 'zod/v4';
 
 export const PromptType = {
@@ -97,12 +99,13 @@ export class McpController {
   }
 
   @MCPTool()
-  async traceTest(@Extra() extra: ToolExtra): Promise<MCPToolResponse> {
+  async traceTest(@Context() ctx: EggContext, @Extra() extra: ToolExtra): Promise<MCPToolResponse> {
+    void extra;
     return {
       content: [
         {
           type: 'text',
-          text: `hello ${extra.requestInfo?.headers.trace}`,
+          text: `hello ${ctx.request.headers.trace}`,
         },
       ],
     };

--- a/plugin/controller/test/fixtures/apps/mcp-app/app/controller/TestController.ts
+++ b/plugin/controller/test/fixtures/apps/mcp-app/app/controller/TestController.ts
@@ -15,7 +15,9 @@ import {
   ToolArgsSchema,
   Extra,
   ToolExtra,
+  Context,
 } from '@eggjs/tegg';
+import type { Context as EggContext } from 'egg';
 import * as z from 'zod/v4';
 
 export const PromptType = {
@@ -93,12 +95,13 @@ export class TestMcpController {
   }
 
   @MCPTool()
-  async testTraceTest(@Extra() extra: ToolExtra): Promise<MCPToolResponse> {
+  async testTraceTest(@Context() ctx: EggContext, @Extra() extra: ToolExtra): Promise<MCPToolResponse> {
+    void extra;
     return {
       content: [
         {
           type: 'text',
-          text: `hello ${extra.requestInfo?.headers.trace}`,
+          text: `hello ${ctx.request.headers.trace}`,
         },
       ],
     };

--- a/plugin/controller/test/mcp/helper.test.ts
+++ b/plugin/controller/test/mcp/helper.test.ts
@@ -30,6 +30,7 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       name: 'test',
       version: '1.0.0',
       hooks: [],
+      getContext: () => ({ trace: 'context' }),
     });
 
     const resourceMeta = new MCPResourceMeta({
@@ -37,12 +38,14 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       needAcl: false,
       middlewares: [],
       uri: 'mcp://npm/egg?version=4.10.0',
+      contextParamIndex: 1,
     });
 
     const toolMeta = new MCPToolMeta({
       name: 'testTool',
       needAcl: false,
       middlewares: [],
+      contextParamIndex: 1,
       detail: {
         argsSchema: ToolType,
         index: 0,
@@ -55,6 +58,7 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       middlewares: [],
       description: 'description',
       title: 'title',
+      contextParamIndex: 1,
       detail: {
         argsSchema: PromptType,
         index: 0,
@@ -62,7 +66,8 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
     });
 
     const getOrCreateEggObject = () => ({ obj: {
-      [promptMeta.name]: args => {
+      [promptMeta.name]: (args, ctx) => {
+        assert.deepEqual(ctx, { trace: 'context' });
         return {
           messages: [
             {
@@ -75,7 +80,8 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
           ],
         };
       },
-      [toolMeta.name]: args => {
+      [toolMeta.name]: (args, ctx) => {
+        assert.deepEqual(ctx, { trace: 'context' });
         return {
           content: [
             {
@@ -85,7 +91,8 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
           ],
         };
       },
-      [resourceMeta.name]: uri => {
+      [resourceMeta.name]: (uri, ctx) => {
+        assert.deepEqual(ctx, { trace: 'context' });
         return {
           contents: [
             {

--- a/standalone/service-worker/src/mcp/MCPControllerRegister.ts
+++ b/standalone/service-worker/src/mcp/MCPControllerRegister.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { IncomingMessage, OutgoingHttpHeader, OutgoingHttpHeaders, ServerResponse } from 'node:http';
 import { Socket } from 'node:net';
 import { Readable, PassThrough } from 'node:stream';
@@ -112,6 +113,7 @@ export class MCPControllerRegister implements ControllerRegister {
   mcpServerHelperMap: Record<string, () => MCPServerHelper> = {};
   streamTransports: Record<string, StreamableHTTPServerTransport> = {};
   middlewaresMap: Record<string, Array<(ctx: ServiceWorkerFetchContext, next: () => Promise<void>) => Promise<void>>> = {};
+  private readonly contextStorage = new AsyncLocalStorage<ServiceWorkerFetchContext>();
   registerMap: Record<string, {
     tools: ServerRegisterRecord<MCPToolMeta>[];
     prompts: ServerRegisterRecord<MCPPromptMeta>[];
@@ -231,7 +233,9 @@ export class MCPControllerRegister implements ControllerRegister {
       const body = await ctx.event.request.json();
 
       // Handle the request (don't await - handleRequest writes to response stream)
-      transport.handleRequest(req, response, body);
+      this.contextStorage.run(ctx, () => {
+        transport.handleRequest(req, response, body);
+      });
 
       const init = await resPromise;
 
@@ -297,6 +301,7 @@ export class MCPControllerRegister implements ControllerRegister {
           return new MCPServerHelper({
             name: this.controllerMeta.name ?? `mcp-${metadata.name ?? 'default'}-server`,
             version: this.controllerMeta.version ?? '1.0.0',
+            getContext: () => this.contextStorage.getStore(),
           });
         };
       }

--- a/standalone/service-worker/src/mcp/MCPControllerRegister.ts
+++ b/standalone/service-worker/src/mcp/MCPControllerRegister.ts
@@ -234,7 +234,15 @@ export class MCPControllerRegister implements ControllerRegister {
 
       // Handle the request (don't await - handleRequest writes to response stream)
       this.contextStorage.run(ctx, () => {
-        transport.handleRequest(req, response, body);
+        void transport.handleRequest(req, response, body).catch(err => {
+          console.error('handle MCP request failed:', err);
+          if (!response.writableEnded) {
+            if (!response.headersSent) {
+              response.writeHead(500, { 'content-type': 'text/plain' });
+            }
+            response.end(err instanceof Error ? err.message : String(err));
+          }
+        });
       });
 
       const init = await resPromise;

--- a/standalone/service-worker/src/mcp/MCPServerHelper.ts
+++ b/standalone/service-worker/src/mcp/MCPServerHelper.ts
@@ -11,10 +11,12 @@ import { MCPControllerMeta, MCPPromptMeta, MCPResourceMeta, MCPToolMeta } from '
 export interface MCPServerHelperOptions {
   name: string;
   version: string;
+  getContext?: () => unknown;
 }
 
 export class MCPServerHelper {
   server: McpServer;
+  private readonly getContext?: () => unknown;
 
   constructor(opts: MCPServerHelperOptions) {
     this.server = new McpServer(
@@ -24,6 +26,46 @@ export class MCPServerHelper {
       },
       { capabilities: { logging: {} } },
     );
+    this.getContext = opts.getContext;
+  }
+
+  private buildResourceArgs(args: any[], resourceMeta: MCPResourceMeta) {
+    const newArgs = [ ...args ];
+    if (resourceMeta.extra !== undefined) {
+      newArgs[resourceMeta.extra] = resourceMeta.template ? args[2] : args[1];
+    }
+    if (resourceMeta.contextParamIndex !== undefined) {
+      newArgs[resourceMeta.contextParamIndex] = this.getContext?.();
+    }
+    return newArgs;
+  }
+
+  private buildToolArgs(args: any[], toolMeta: MCPToolMeta, hasSchema: boolean) {
+    const newArgs = [ ...args ];
+    if (hasSchema && toolMeta.detail) {
+      newArgs[toolMeta.detail.index] = args[0];
+    }
+    if (toolMeta.extra !== undefined) {
+      newArgs[toolMeta.extra] = hasSchema ? args[1] : args[0];
+    }
+    if (toolMeta.contextParamIndex !== undefined) {
+      newArgs[toolMeta.contextParamIndex] = this.getContext?.();
+    }
+    return newArgs;
+  }
+
+  private buildPromptArgs(args: any[], promptMeta: MCPPromptMeta, hasSchema: boolean) {
+    const newArgs = [ ...args ];
+    if (hasSchema && promptMeta.detail) {
+      newArgs[promptMeta.detail.index] = args[0];
+    }
+    if (promptMeta.extra !== undefined) {
+      newArgs[promptMeta.extra] = hasSchema ? args[1] : args[0];
+    }
+    if (promptMeta.contextParamIndex !== undefined) {
+      newArgs[promptMeta.contextParamIndex] = this.getContext?.();
+    }
+    return newArgs;
   }
 
   async mcpResourceRegister(
@@ -38,10 +80,11 @@ export class MCPServerHelper {
       );
       const realObj = eggObj.obj;
       const realMethod = realObj[resourceMeta.name];
+      const newArgs = this.buildResourceArgs(args, resourceMeta);
       return Reflect.apply(
         realMethod,
         realObj,
-        args,
+        newArgs,
       ) as ReturnType<ReadResourceCallback>;
     };
     const name = resourceMeta.mcpName ?? resourceMeta.name;
@@ -76,16 +119,7 @@ export class MCPServerHelper {
       );
       const realObj = eggObj.obj;
       const realMethod = realObj[toolMeta.name];
-      let newArgs: any[] = [];
-      if (schema && toolMeta.detail) {
-        newArgs[toolMeta.detail.index] = args[0];
-        if (toolMeta.extra) {
-          newArgs[toolMeta.extra] = args[1];
-        }
-      } else if (toolMeta.extra) {
-        newArgs[toolMeta.extra] = args[0];
-      }
-      newArgs = [ ...newArgs, ...args ];
+      const newArgs = this.buildToolArgs(args, toolMeta, !!schema);
       return Reflect.apply(realMethod, realObj, newArgs) as ReturnType<ToolCallback>;
     };
     this.server.registerTool(name, {
@@ -109,16 +143,7 @@ export class MCPServerHelper {
       const eggObj = await getOrCreateEggObject(controllerProto, controllerProto.name);
       const realObj = eggObj.obj;
       const realMethod = realObj[promptMeta.name];
-      let newArgs: any[] = [];
-      if (schema && promptMeta.detail) {
-        newArgs[promptMeta.detail.index] = args[0];
-        if (promptMeta.extra) {
-          newArgs[promptMeta.extra] = args[1];
-        }
-      } else if (promptMeta.extra) {
-        newArgs[promptMeta.extra] = args[0];
-      }
-      newArgs = [ ...newArgs, ...args ];
+      const newArgs = this.buildPromptArgs(args, promptMeta, !!schema);
       return Reflect.apply(realMethod, realObj, newArgs) as ReturnType<PromptCallback>;
     };
     this.server.registerPrompt(name, {

--- a/standalone/service-worker/test/fixtures/mcp/MCPTestController.ts
+++ b/standalone/service-worker/test/fixtures/mcp/MCPTestController.ts
@@ -24,7 +24,7 @@ export class MCPTestController {
 
   @MCPTool({ description: 'Add two numbers' })
   async add(@ToolArgsSchema(AddArgs) args: ToolArgs<typeof AddArgs>, @Context() ctx: ServiceWorkerFetchContext): Promise<MCPToolResponse> {
-    if (!ctx.event?.request) {
+    if (!ctx?.event?.request) {
       throw new Error('ctx is required');
     }
     return {

--- a/standalone/service-worker/test/fixtures/mcp/MCPTestController.ts
+++ b/standalone/service-worker/test/fixtures/mcp/MCPTestController.ts
@@ -1,6 +1,7 @@
-import { MCPController, MCPTool, MCPToolResponse, ToolArgsSchema, ToolArgs, Middleware } from '@eggjs/tegg';
+import { Context, MCPController, MCPTool, MCPToolResponse, ToolArgsSchema, ToolArgs, Middleware } from '@eggjs/tegg';
 import * as z from 'zod/v4';
 import { McpTestAdvice } from './McpTestAdvice';
+import type { ServiceWorkerFetchContext } from '../../../src/http/ServiceWorkerFetchContext';
 
 const EchoArgs = {
   message: z.string().describe('The message to echo'),
@@ -22,7 +23,10 @@ export class MCPTestController {
   }
 
   @MCPTool({ description: 'Add two numbers' })
-  async add(@ToolArgsSchema(AddArgs) args: ToolArgs<typeof AddArgs>): Promise<MCPToolResponse> {
+  async add(@ToolArgsSchema(AddArgs) args: ToolArgs<typeof AddArgs>, @Context() ctx: ServiceWorkerFetchContext): Promise<MCPToolResponse> {
+    if (!ctx.event?.request) {
+      throw new Error('ctx is required');
+    }
     return {
       content: [{ type: 'text', text: String(args.a + args.b) }],
     };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added context parameter support for MCP tools, resources, and prompts—handlers can now inject and access request context via the `@Context`() decorator.

* **Tests**
  * Updated MCP tests to validate context parameter injection and retrieval in handler operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->