### PR TITLE
feat(mcp): support UI metadata for tool registration

### DIFF
--- a/core/controller-decorator/src/model/MCPToolMeta.ts
+++ b/core/controller-decorator/src/model/MCPToolMeta.ts
@@ -1,4 +1,4 @@
-import type { MethodMeta, MiddlewareFunc } from '@eggjs/tegg-types';
+import type { MCPToolParams, MethodMeta, MiddlewareFunc } from '@eggjs/tegg-types';
 import { ToolArgsSchemaDetail } from '../../src/util/MCPInfoUtil';
 
 
@@ -8,6 +8,7 @@ export class MCPToolMeta implements MethodMeta {
   readonly aclCode?: string;
   readonly mcpName?: string;
   readonly description?: string;
+  readonly meta?: MCPToolParams['meta'];
   readonly detail?: ToolArgsSchemaDetail;
   readonly middlewares: readonly MiddlewareFunc[];
   readonly extra?: number;
@@ -20,6 +21,7 @@ export class MCPToolMeta implements MethodMeta {
     needAcl?: boolean;
     aclCode?: string,
     description?: string;
+    meta?: MCPToolParams['meta'];
     mcpName?: string;
     detail?: ToolArgsSchemaDetail;
     extra?: number;
@@ -27,6 +29,7 @@ export class MCPToolMeta implements MethodMeta {
     this.name = opt.name;
     this.needAcl = !!opt.needAcl;
     this.description = opt.description;
+    this.meta = opt.meta;
     this.mcpName = opt.mcpName;
     this.middlewares = opt.middlewares;
     this.aclCode = opt.aclCode;

--- a/core/controller-decorator/test/MCPMeta.test.ts
+++ b/core/controller-decorator/test/MCPMeta.test.ts
@@ -17,6 +17,12 @@ describe('test/MCPMeta.test.ts', () => {
     assert(fooControllerMetaData.className === 'MCPFooController');
     assert(fooControllerMetaData.prompts[0].name === 'foo');
     assert(fooControllerMetaData.tools[0].name === 'bar');
+    assert.deepStrictEqual(fooControllerMetaData.tools[0].meta, {
+      ui: {
+        resourceUri: 'ui://test/tool',
+        visibility: [ 'model', 'app' ],
+      },
+    });
     assert(fooControllerMetaData.resources[0].name === 'car');
     assert(fooControllerMetaData.resources[0].template instanceof ResourceTemplate);
     assert.strictEqual(fooControllerMetaData.tools[0].detail?.argsSchema as unknown, ToolType);

--- a/core/controller-decorator/test/fixtures/MCPController.ts
+++ b/core/controller-decorator/test/fixtures/MCPController.ts
@@ -36,7 +36,14 @@ export class MCPFooController {
     };
   }
 
-  @MCPTool()
+  @MCPTool({
+    meta: {
+      ui: {
+        resourceUri: 'ui://test/tool',
+        visibility: [ 'model', 'app' ],
+      },
+    },
+  })
   async bar(@ToolArgsSchema(ToolType as any) args: ToolArgs<any>, @Context() ctx: object): Promise<MCPToolResponse> {
     void ctx;
     return {

--- a/core/types/controller-decorator/MCPToolParams.ts
+++ b/core/types/controller-decorator/MCPToolParams.ts
@@ -7,9 +7,20 @@ export type ToolExtra = Parameters<Parameters<McpServer['tool']>['4']>['1'];
 
 export type MCPToolResponse = CallToolResult;
 
+export type MCPToolVisibility = 'model' | 'app';
+
+export interface MCPToolUIMeta {
+  resourceUri?: string;
+  visibility?: MCPToolVisibility[];
+}
+
+export type MCPToolRegistrationMeta = {
+  ui: MCPToolUIMeta;
+};
+
 export interface MCPToolParams {
   name?: string;
   description?: string;
   timeout?: number;
+  meta?: MCPToolRegistrationMeta;
 }
-

--- a/plugin/controller/lib/impl/mcp/MCPServerHelper.ts
+++ b/plugin/controller/lib/impl/mcp/MCPServerHelper.ts
@@ -137,6 +137,7 @@ export class MCPServerHelper {
     this.server.registerTool(name, {
       description,
       inputSchema: schema,
+      _meta: toolMeta.meta,
       // TODO: outputSchema
     }, handler);
   }

--- a/plugin/controller/test/mcp/helper.test.ts
+++ b/plugin/controller/test/mcp/helper.test.ts
@@ -45,6 +45,12 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       name: 'testTool',
       needAcl: false,
       middlewares: [],
+      meta: {
+        ui: {
+          resourceUri: 'ui://test/tool',
+          visibility: [ 'model', 'app' ],
+        },
+      },
       contextParamIndex: 1,
       detail: {
         argsSchema: ToolType,
@@ -128,10 +134,16 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
     ]);
     const tools = await client.listTools();
 
-    assert.deepEqual(tools.tools.map(tool => ({ name: tool.name, description: tool.description })), [
+    assert.deepEqual(tools.tools.map(tool => ({ name: tool.name, description: tool.description, _meta: tool._meta })), [
       {
         description: undefined,
         name: 'testTool',
+        _meta: {
+          ui: {
+            resourceUri: 'ui://test/tool',
+            visibility: [ 'model', 'app' ],
+          },
+        },
       },
     ]);
 

--- a/standalone/service-worker/src/mcp/MCPServerHelper.ts
+++ b/standalone/service-worker/src/mcp/MCPServerHelper.ts
@@ -125,6 +125,7 @@ export class MCPServerHelper {
     this.server.registerTool(name, {
       description,
       inputSchema: schema,
+      _meta: toolMeta.meta,
     }, handler);
   }
 

--- a/standalone/service-worker/test/fixtures/mcp/MCPTestController.ts
+++ b/standalone/service-worker/test/fixtures/mcp/MCPTestController.ts
@@ -15,7 +15,15 @@ const AddArgs = {
 @Middleware(McpTestAdvice)
 @MCPController({ name: 'test-server', version: '1.0.0' })
 export class MCPTestController {
-  @MCPTool({ description: 'Echo the input message' })
+  @MCPTool({
+    description: 'Echo the input message',
+    meta: {
+      ui: {
+        resourceUri: 'ui://test/echo',
+        visibility: [ 'model' ],
+      },
+    },
+  })
   async echo(@ToolArgsSchema(EchoArgs) args: ToolArgs<typeof EchoArgs>): Promise<MCPToolResponse> {
     return {
       content: [{ type: 'text', text: args.message }],

--- a/standalone/service-worker/test/mcp/mcp.test.ts
+++ b/standalone/service-worker/test/mcp/mcp.test.ts
@@ -47,6 +47,12 @@ describe('standalone/service-worker/test/mcp/mcp.test.ts', () => {
 
     const echoTool = result.tools.find(t => t.name === 'echo');
     assert.strictEqual(echoTool?.description, 'Echo the input message');
+    assert.deepStrictEqual(echoTool?._meta, {
+      ui: {
+        resourceUri: 'ui://test/echo',
+        visibility: [ 'model' ],
+      },
+    });
 
     const addTool = result.tools.find(t => t.name === 'add');
     assert.strictEqual(addTool?.description, 'Add two numbers');


### PR DESCRIPTION
## Summary

- add typed `meta.ui` configuration to `MCPTool`
- preserve TEGG-facing `meta` and map it to MCP SDK `_meta` during tool registration
- support both controller plugin and standalone service worker runtimes

## Testing

- focused controller decorator metadata test
- focused controller plugin MCP registration test
- focused service worker MCP tool listing test
- `tsc:pub` for tegg-types, controller-decorator, controller plugin, and service worker
- repository `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP tool registrations can now include optional UI metadata, including a `resourceUri` and `visibility` (limited to model/app).
  * This UI metadata is preserved during registration and returned when tools are listed, enabling more reliable UI discovery.

* **Tests**
  * Expanded tool-listing assertions to deep-verify each tool’s returned UI metadata (`resourceUri` and `visibility`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->