### PR TITLE
perf(agent-runtime): skip thinking token progress persistence

### DIFF
--- a/core/agent-runtime/src/AgentRuntime.ts
+++ b/core/agent-runtime/src/AgentRuntime.ts
@@ -689,10 +689,11 @@ export class AgentRuntime {
    *   `streamMessages` has been mirrored; cursor/flags only advance after a
    *   successful append, so a failed append is retried (never duplicated and
    *   never silently dropped) by the next flush.
-   * - **Storage filter**: `stream_event` deltas are never persisted.
+   * - **Storage filter**: `stream_event` deltas and
+   *   `system/thinking_tokens` progress counters are never persisted.
    *
-   * The persisted transcript is input messages followed by every
-   * non-`stream_event` message in order.
+   * The persisted transcript is input messages followed by every non-transient
+   * message emitted by the executor.
    */
   private createMessageFlusher(
     threadId: string,

--- a/core/agent-runtime/src/MessageConverter.ts
+++ b/core/agent-runtime/src/MessageConverter.ts
@@ -55,13 +55,16 @@ export class MessageConverter {
   }
 
   /**
-   * Filter out stream_event messages before persisting to thread storage.
-   * Stream events are incremental deltas (one per token) only useful during
-   * real-time streaming; the final assistant message already contains the
-   * complete response.
+   * Filter transient progress messages before persisting to thread storage.
+   * Stream events are incremental content deltas, while thinking_tokens only
+   * reports estimated token-count progress. The final assistant messages
+   * already contain the complete response and thinking content.
    */
   static filterForStorage(messages: AgentMessage[]): AgentMessage[] {
-    return messages.filter(m => m.type !== 'stream_event');
+    return messages.filter(
+      m => m.type !== 'stream_event' &&
+        !(m.type === 'system' && m.subtype === 'thinking_tokens'),
+    );
   }
 
   /**

--- a/core/agent-runtime/test/AgentRuntime.test.ts
+++ b/core/agent-runtime/test/AgentRuntime.test.ts
@@ -5,6 +5,7 @@ import type {
   RunRecord,
   CreateRunInput,
   AgentMessage,
+  SDKAssistantMessage,
   SDKResultMessage,
   StreamEvent,
 } from '@eggjs/tegg-types/agent-runtime';
@@ -623,6 +624,56 @@ describe('test/AgentRuntime.test.ts', () => {
       assert(eventTypes.includes('system'), 'should forward system event');
       assert(eventTypes.includes('stream_event'), 'should forward stream_event');
       assert(eventTypes.includes('assistant'), 'should forward assistant event');
+    });
+
+    it('should forward thinking_tokens without persisting them', async () => {
+      const thinkingTokens: AgentMessage = {
+        type: 'system',
+        subtype: 'thinking_tokens',
+        estimated_tokens: 1,
+        estimated_tokens_delta: 1,
+      };
+      const assistant: SDKAssistantMessage = {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'complete reasoning' },
+            { type: 'text', text: 'Hello' },
+          ],
+        },
+      };
+      executor.execRun = async function* (): AsyncGenerator<AgentMessage> {
+        yield { type: 'system', subtype: 'init', session_id: 'sess-1' };
+        yield thinkingTokens;
+        yield assistant;
+      };
+
+      const writer = new MockSSEWriter();
+      await runtime.streamRun({ input: { messages: [{ role: 'user', content: 'Hi' }] } }, writer);
+
+      const thinkingEvent = writer.events.find(event => {
+        if (event.event !== 'system') return false;
+        const streamEvent = event.data as StreamEvent;
+        return (streamEvent.data as AgentMessage).subtype === 'thinking_tokens';
+      });
+      assert.ok(thinkingEvent, 'should forward thinking_tokens over SSE');
+      assert.deepStrictEqual((thinkingEvent.data as StreamEvent).data, thinkingTokens);
+
+      const runCreated = writer.events[0].data as StreamEvent;
+      const threadId = (runCreated.data as { threadId: string }).threadId;
+      const thread = await runtime.getThread(threadId);
+      assert.equal(
+        thread.messages.some(message =>
+          message.type === 'system' && message.subtype === 'thinking_tokens',
+        ),
+        false,
+      );
+      const persistedAssistant = thread.messages.find(
+        (message): message is SDKAssistantMessage => message.type === 'assistant',
+      );
+      assert.ok(persistedAssistant);
+      assert.deepStrictEqual(persistedAssistant.message, assistant.message);
     });
 
     it('should pass through SDK message directly as event data', async () => {

--- a/core/agent-runtime/test/MessageConverter.test.ts
+++ b/core/agent-runtime/test/MessageConverter.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert';
 
-import type { AgentMessage, InputMessage, SDKResultMessage } from '@eggjs/tegg-types/agent-runtime';
+import type {
+  AgentMessage,
+  InputMessage,
+  SDKAssistantMessage,
+  SDKResultMessage,
+} from '@eggjs/tegg-types/agent-runtime';
 
 import { MessageConverter } from '../src/MessageConverter';
 
@@ -134,13 +139,29 @@ describe('test/MessageConverter.test.ts', () => {
   });
 
   describe('filterForStorage', () => {
-    it('should filter out stream_event messages', () => {
+    it('should filter out stream_event and thinking_tokens messages', () => {
+      const assistant = {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'complete reasoning' },
+            { type: 'text', text: 'hi' },
+          ],
+        },
+      } satisfies SDKAssistantMessage;
       const messages: AgentMessage[] = [
         { type: 'system', subtype: 'init', session_id: 'sess-1' },
         { type: 'user', message: { role: 'user', content: 'hello' } },
+        {
+          type: 'system',
+          subtype: 'thinking_tokens',
+          estimated_tokens: 1,
+          estimated_tokens_delta: 1,
+        },
         { type: 'stream_event', event: { type: 'content_block_delta' }, session_id: 'sess-1' },
         { type: 'stream_event', event: { type: 'content_block_delta' }, session_id: 'sess-1' },
-        { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } },
+        assistant,
         { type: 'result', subtype: 'success', usage: { input_tokens: 10, output_tokens: 5 } } as SDKResultMessage,
       ];
       const result = MessageConverter.filterForStorage(messages);
@@ -149,9 +170,14 @@ describe('test/MessageConverter.test.ts', () => {
       assert.equal(result[1].type, 'user');
       assert.equal(result[2].type, 'assistant');
       assert.equal(result[3].type, 'result');
+      assert.strictEqual(result[2], assistant);
+      assert.deepStrictEqual(assistant.message.content, [
+        { type: 'thinking', thinking: 'complete reasoning' },
+        { type: 'text', text: 'hi' },
+      ]);
     });
 
-    it('should return all messages when no stream_event present', () => {
+    it('should return all messages when no transient messages are present', () => {
       const messages: AgentMessage[] = [
         { type: 'user', message: { role: 'user', content: 'hello' } },
         { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } },


### PR DESCRIPTION
## Summary

- exclude `system/thinking_tokens` progress counters from thread message persistence
- keep those events available through `/runs/stream` and run-event replay
- preserve the final assistant message, including its complete `thinking` content
- cover the behavior at both `MessageConverter` and `AgentRuntime` integration levels

## Root cause

After a run commits, the incremental message flusher attempts to mirror every executor message into the thread store. `thinking_tokens` is emitted frequently as a progress counter, so persisting it creates one awaited remote append per update on OSS/FUSE-backed stores and backpressures consumption of subsequent model events.

The counter is transient metadata rather than conversation history. Filtering it at the existing storage boundary removes that write amplification without changing the streaming protocol or final transcript.

## Validation

- `core/agent-runtime`: `ut run test` (210 passing)
- `core/agent-runtime`: `ut run tsc`
- `core/agent-runtime`: `ut run tsc:pub`
- repository lint: `ut run lint`
- independent correctness/security review: LGTM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript persistence by excluding temporary streaming events and thinking-progress updates.
  * Preserved assistant responses and their thinking content unchanged in stored conversations.
  * Streaming clients continue to receive thinking-progress updates in real time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->