### PR TITLE
feat(mcp): support tool output schema

### DIFF
--- a/core/controller-decorator/src/model/MCPToolMeta.ts
+++ b/core/controller-decorator/src/model/MCPToolMeta.ts
@@ -9,6 +9,7 @@ export class MCPToolMeta implements MethodMeta {
   readonly mcpName?: string;
   readonly description?: string;
   readonly meta?: MCPToolParams['meta'];
+  readonly outputSchema?: MCPToolParams['outputSchema'];
   readonly detail?: ToolArgsSchemaDetail;
   readonly middlewares: readonly MiddlewareFunc[];
   readonly extra?: number;
@@ -22,6 +23,7 @@ export class MCPToolMeta implements MethodMeta {
     aclCode?: string,
     description?: string;
     meta?: MCPToolParams['meta'];
+    outputSchema?: MCPToolParams['outputSchema'];
     mcpName?: string;
     detail?: ToolArgsSchemaDetail;
     extra?: number;
@@ -30,6 +32,7 @@ export class MCPToolMeta implements MethodMeta {
     this.needAcl = !!opt.needAcl;
     this.description = opt.description;
     this.meta = opt.meta;
+    this.outputSchema = opt.outputSchema;
     this.mcpName = opt.mcpName;
     this.middlewares = opt.middlewares;
     this.aclCode = opt.aclCode;

--- a/core/controller-decorator/test/MCPMeta.test.ts
+++ b/core/controller-decorator/test/MCPMeta.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { ControllerType } from '@eggjs/tegg-types';
-import { MCPFooController, ToolType, PromptType } from './fixtures/MCPController';
+import { MCPFooController, ToolType, ToolOutputType, PromptType } from './fixtures/MCPController';
 import { ControllerMetaBuilderFactory, MCPControllerMeta } from '..';
 import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -23,6 +23,7 @@ describe('test/MCPMeta.test.ts', () => {
         visibility: [ 'model', 'app' ],
       },
     });
+    assert.strictEqual(fooControllerMetaData.tools[0].outputSchema, ToolOutputType);
     assert(fooControllerMetaData.resources[0].name === 'car');
     assert(fooControllerMetaData.resources[0].template instanceof ResourceTemplate);
     assert.strictEqual(fooControllerMetaData.tools[0].detail?.argsSchema as unknown, ToolType);

--- a/core/controller-decorator/test/fixtures/MCPController.ts
+++ b/core/controller-decorator/test/fixtures/MCPController.ts
@@ -15,6 +15,11 @@ export const ToolType = {
   name: z.string().describe('npm package name'),
 }
 
+export const ToolOutputType = {
+  packageName: z.string(),
+  found: z.boolean(),
+}
+
 @MCPController({
   name: "HelloChairMCP",
   timeout: 60000,
@@ -37,6 +42,7 @@ export class MCPFooController {
   }
 
   @MCPTool({
+    outputSchema: ToolOutputType,
     meta: {
       ui: {
         resourceUri: 'ui://test/tool',
@@ -44,7 +50,7 @@ export class MCPFooController {
       },
     },
   })
-  async bar(@ToolArgsSchema(ToolType as any) args: ToolArgs<any>, @Context() ctx: object): Promise<MCPToolResponse> {
+  async bar(@ToolArgsSchema(ToolType as any) args: ToolArgs<any>, @Context() ctx: object): Promise<MCPToolResponse<typeof ToolOutputType>> {
     void ctx;
     return {
       content: [
@@ -53,6 +59,10 @@ export class MCPFooController {
           text: `海兔 npm 包: ${args.name} 不存在`,
         },
       ],
+      structuredContent: {
+        packageName: args.name,
+        found: false,
+      },
     };
   }
 

--- a/core/types/controller-decorator/MCPToolParams.ts
+++ b/core/types/controller-decorator/MCPToolParams.ts
@@ -1,11 +1,26 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { ShapeOutput } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import type { ShapeOutput, ZodRawShapeCompat } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 
 export type ToolArgs<T extends Parameters<McpServer['tool']>['2']> = ShapeOutput<T>;
 export type ToolExtra = Parameters<Parameters<McpServer['tool']>['4']>['1'];
 
-export type MCPToolResponse = CallToolResult;
+export type ToolOutputSchema = ZodRawShapeCompat;
+
+export type MCPToolSuccessResponse<OutputSchema extends ToolOutputSchema> =
+  Omit<CallToolResult, 'isError' | 'structuredContent'> & {
+    isError?: false;
+    structuredContent: ShapeOutput<OutputSchema>;
+  };
+
+export type MCPToolErrorResponse = Omit<CallToolResult, 'isError'> & {
+  isError: true;
+};
+
+export type MCPToolResponse<OutputSchema extends ToolOutputSchema | undefined = undefined> =
+  [OutputSchema] extends [ToolOutputSchema]
+    ? MCPToolSuccessResponse<Extract<OutputSchema, ToolOutputSchema>> | MCPToolErrorResponse
+    : CallToolResult;
 
 export type MCPToolVisibility = 'model' | 'app';
 
@@ -23,4 +38,5 @@ export interface MCPToolParams {
   description?: string;
   timeout?: number;
   meta?: MCPToolRegistrationMeta;
+  outputSchema?: ToolOutputSchema;
 }

--- a/plugin/controller/README.md
+++ b/plugin/controller/README.md
@@ -236,7 +236,7 @@ import {
   Inject,
   ToolArgsSchema,
 } from '@eggjs/tegg';
-import * as z from 'zod/v4';
+import { z } from '@eggjs/tegg/zod';
 
 export const PromptType = {
   name: z.string(),
@@ -244,6 +244,11 @@ export const PromptType = {
 
 export const ToolType = {
   name: z.string().describe('npm package name'),
+};
+
+export const ToolOutputType = {
+  packageName: z.string(),
+  found: z.boolean(),
 };
 
 @MCPController()
@@ -268,8 +273,12 @@ export class McpController {
     };
   }
 
-  @MCPTool()
-  async bar(@ToolArgsSchema(ToolType) args: ToolArgs<typeof ToolType>): Promise<MCPToolResponse> {
+  @MCPTool({ outputSchema: ToolOutputType })
+  async bar(@ToolArgsSchema(ToolType) args: ToolArgs<typeof ToolType>): Promise<MCPToolResponse<typeof ToolOutputType>> {
+    const output = {
+      packageName: args.name,
+      found: false,
+    };
     return {
       content: [
         {
@@ -277,6 +286,7 @@ export class McpController {
           text: `npm package: ${args.name} not found`,
         },
       ],
+      structuredContent: output,
     };
   }
 

--- a/plugin/controller/lib/impl/mcp/MCPServerHelper.ts
+++ b/plugin/controller/lib/impl/mcp/MCPServerHelper.ts
@@ -137,8 +137,8 @@ export class MCPServerHelper {
     this.server.registerTool(name, {
       description,
       inputSchema: schema,
+      outputSchema: toolMeta.outputSchema,
       _meta: toolMeta.meta,
-      // TODO: outputSchema
     }, handler);
   }
 

--- a/plugin/controller/test/mcp/helper.test.ts
+++ b/plugin/controller/test/mcp/helper.test.ts
@@ -4,6 +4,7 @@ import {
   MCPPromptMeta,
 } from '@eggjs/controller-decorator';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import * as z from 'zod/v4';
 import assert from 'assert';
 
@@ -26,6 +27,11 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       name: z.string().describe('npm package name'),
     };
 
+    const ToolOutputType = {
+      packageName: z.string(),
+      found: z.boolean(),
+    };
+
     const helper = new MCPServerHelper({
       name: 'test',
       version: '1.0.0',
@@ -45,6 +51,7 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
       name: 'testTool',
       needAcl: false,
       middlewares: [],
+      outputSchema: ToolOutputType,
       meta: {
         ui: {
           resourceUri: 'ui://test/tool',
@@ -56,6 +63,13 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
         argsSchema: ToolType,
         index: 0,
       },
+    });
+
+    const invalidOutputToolMeta = new MCPToolMeta({
+      name: 'invalidOutputTool',
+      needAcl: false,
+      middlewares: [],
+      outputSchema: ToolOutputType,
     });
 
     const promptMeta = new MCPPromptMeta({
@@ -95,6 +109,19 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
               text: `npm package: ${args.name} not found`,
             },
           ],
+          structuredContent: {
+            packageName: args.name,
+            found: false,
+          },
+        };
+      },
+      [invalidOutputToolMeta.name]: () => {
+        return {
+          content: [{ type: 'text', text: 'invalid output' }],
+          structuredContent: {
+            packageName: 'aaa',
+            found: 'not-a-boolean',
+          },
         };
       },
       [resourceMeta.name]: (uri, ctx) => {
@@ -111,6 +138,7 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
     } });
 
     await helper.mcpToolRegister(getOrCreateEggObject as any, { getMetaData: () => ({}) } as any, toolMeta);
+    await helper.mcpToolRegister(getOrCreateEggObject as any, { getMetaData: () => ({}) } as any, invalidOutputToolMeta);
     await helper.mcpResourceRegister(getOrCreateEggObject as any, { getMetaData: () => ({}) } as any, resourceMeta);
     await helper.mcpPromptRegister(getOrCreateEggObject as any, { getMetaData: () => ({}) } as any, promptMeta);
 
@@ -134,6 +162,12 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
     ]);
     const tools = await client.listTools();
 
+    assert.deepEqual(tools.tools[0].outputSchema?.properties, {
+      packageName: { type: 'string' },
+      found: { type: 'boolean' },
+    });
+    assert.deepEqual(tools.tools[0].outputSchema?.required, [ 'packageName', 'found' ]);
+
     assert.deepEqual(tools.tools.map(tool => ({ name: tool.name, description: tool.description, _meta: tool._meta })), [
       {
         description: undefined,
@@ -145,6 +179,11 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
           },
         },
       },
+      {
+        description: undefined,
+        name: 'invalidOutputTool',
+        _meta: undefined,
+      },
     ]);
 
     const toolRes = await client.callTool({
@@ -155,7 +194,21 @@ describe('plugin/controller/test/mcp/mcp.test.ts', () => {
     });
     assert.deepEqual(toolRes, {
       content: [{ type: 'text', text: 'npm package: aaa not found' }],
+      structuredContent: {
+        packageName: 'aaa',
+        found: false,
+      },
     });
+    const invalidOutputToolRes = await client.callTool({
+      name: 'invalidOutputTool',
+      arguments: {},
+    }) as CallToolResult;
+    assert.equal(invalidOutputToolRes.isError, true);
+    const invalidOutputContent = invalidOutputToolRes.content[0];
+    assert.equal(invalidOutputContent.type, 'text');
+    if (invalidOutputContent.type === 'text') {
+      assert.match(invalidOutputContent.text, /Output validation error/);
+    }
     const resources = await client.listResources();
     assert.deepEqual(resources, {
       resources: [

--- a/standalone/service-worker/src/mcp/MCPServerHelper.ts
+++ b/standalone/service-worker/src/mcp/MCPServerHelper.ts
@@ -125,6 +125,7 @@ export class MCPServerHelper {
     this.server.registerTool(name, {
       description,
       inputSchema: schema,
+      outputSchema: toolMeta.outputSchema,
       _meta: toolMeta.meta,
     }, handler);
   }

--- a/standalone/service-worker/test/fixtures/mcp/MCPTestController.ts
+++ b/standalone/service-worker/test/fixtures/mcp/MCPTestController.ts
@@ -12,6 +12,10 @@ const AddArgs = {
   b: z.number().describe('Second number'),
 };
 
+const AddOutput = {
+  result: z.number(),
+};
+
 @Middleware(McpTestAdvice)
 @MCPController({ name: 'test-server', version: '1.0.0' })
 export class MCPTestController {
@@ -30,13 +34,15 @@ export class MCPTestController {
     };
   }
 
-  @MCPTool({ description: 'Add two numbers' })
-  async add(@ToolArgsSchema(AddArgs) args: ToolArgs<typeof AddArgs>, @Context() ctx: ServiceWorkerFetchContext): Promise<MCPToolResponse> {
+  @MCPTool({ description: 'Add two numbers', outputSchema: AddOutput })
+  async add(@ToolArgsSchema(AddArgs) args: ToolArgs<typeof AddArgs>, @Context() ctx: ServiceWorkerFetchContext): Promise<MCPToolResponse<typeof AddOutput>> {
     if (!ctx?.event?.request) {
       throw new Error('ctx is required');
     }
+    const result = args.a + args.b;
     return {
-      content: [{ type: 'text', text: String(args.a + args.b) }],
+      content: [{ type: 'text', text: String(result) }],
+      structuredContent: { result },
     };
   }
 }

--- a/standalone/service-worker/test/mcp/mcp.test.ts
+++ b/standalone/service-worker/test/mcp/mcp.test.ts
@@ -56,6 +56,10 @@ describe('standalone/service-worker/test/mcp/mcp.test.ts', () => {
 
     const addTool = result.tools.find(t => t.name === 'add');
     assert.strictEqual(addTool?.description, 'Add two numbers');
+    assert.deepStrictEqual(addTool?.outputSchema?.properties, {
+      result: { type: 'number' },
+    });
+    assert.deepStrictEqual(addTool?.outputSchema?.required, [ 'result' ]);
   });
 
   it('should call echo tool', async () => {
@@ -93,6 +97,7 @@ describe('standalone/service-worker/test/mcp/mcp.test.ts', () => {
     });
     assert.deepStrictEqual(result, {
       content: [{ type: 'text', text: '8' }],
+      structuredContent: { result: 8 },
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional output schemas for MCP tools.
  * MCP tools can now return validated, structured output alongside text responses.
  * Added type-safe success and error responses based on declared output schemas.
  * Registered schemas are now exposed and validated when tools are called.

* **Documentation**
  * Updated MCP controller examples to demonstrate structured tool output and schema declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->